### PR TITLE
feat: support .md dialog import for advisor profile generation

### DIFF
--- a/skills/conversation-dump/parse_md_dialog.py
+++ b/skills/conversation-dump/parse_md_dialog.py
@@ -1,0 +1,192 @@
+"""Parse exported .md dialog files into the standard conversation-dump JSON format.
+
+Supports:
+- Claude.ai web export: ## **Human** / ## **Claude** with --- separators
+- Generic markdown: ## Human / ## Assistant variants
+- Auto-detection of role markers
+"""
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_ROLE_PATTERNS = [
+    # Claude.ai bold format: ## **Human** / ## **Claude**
+    (re.compile(r"^##\s+\*\*Human\*\*", re.IGNORECASE), "user"),
+    (re.compile(r"^##\s+\*\*Claude\*\*", re.IGNORECASE), "assistant"),
+    (re.compile(r"^##\s+\*\*Assistant\*\*", re.IGNORECASE), "assistant"),
+    (re.compile(r"^##\s+\*\*User\*\*", re.IGNORECASE), "user"),
+    # Plain format: ## Human / ## Claude / ## Assistant / ## User
+    (re.compile(r"^##\s+Human\s*$", re.IGNORECASE), "user"),
+    (re.compile(r"^##\s+Claude\s*$", re.IGNORECASE), "assistant"),
+    (re.compile(r"^##\s+Assistant\s*$", re.IGNORECASE), "assistant"),
+    (re.compile(r"^##\s+User\s*$", re.IGNORECASE), "user"),
+    # Colon format: **Human:** / **Claude:**
+    (re.compile(r"^\*\*Human\*\*\s*:", re.IGNORECASE), "user"),
+    (re.compile(r"^\*\*Claude\*\*\s*:", re.IGNORECASE), "assistant"),
+    (re.compile(r"^\*\*Assistant\*\*\s*:", re.IGNORECASE), "assistant"),
+    (re.compile(r"^\*\*User\*\*\s*:", re.IGNORECASE), "user"),
+]
+
+
+def _detect_role(line):
+    """Return 'user', 'assistant', or None for a line."""
+    stripped = line.strip()
+    for pattern, role in _ROLE_PATTERNS:
+        if pattern.match(stripped):
+            return role
+    return None
+
+
+def _truncate(text, max_chars=500):
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + "..."
+
+
+def parse_md_file(filepath):
+    """Parse a markdown dialog file into a list of (role, text) segments.
+
+    Strategy: scan line-by-line, detect role markers, and accumulate text
+    between markers. This handles --- separators, blank lines, and nested
+    markdown headings within assistant responses gracefully.
+    """
+    path = Path(filepath)
+    text = path.read_text(encoding="utf-8")
+    lines = text.split("\n")
+
+    segments = []
+    current_role = None
+    current_lines = []
+
+    for line in lines:
+        role = _detect_role(line)
+        if role is not None:
+            if current_role is not None:
+                body = "\n".join(current_lines).strip()
+                if body:
+                    segments.append({"role": current_role, "text": body})
+            current_role = role
+            current_lines = []
+        elif current_role is not None:
+            stripped = line.strip()
+            if stripped == "---":
+                continue
+            current_lines.append(line)
+
+    if current_role is not None:
+        body = "\n".join(current_lines).strip()
+        if body:
+            segments.append({"role": current_role, "text": body})
+
+    return segments
+
+
+def segments_to_turns(segments):
+    """Pair consecutive user+assistant segments into turns."""
+    turns = []
+    idx = 0
+    i = 0
+    while i < len(segments):
+        seg = segments[i]
+        if seg["role"] == "user":
+            user_text = seg["text"]
+            assistant_parts = []
+            i += 1
+            while i < len(segments) and segments[i]["role"] == "assistant":
+                assistant_parts.append(segments[i]["text"])
+                i += 1
+            idx += 1
+            assistant_text = "\n".join(assistant_parts) if assistant_parts else "[no response]"
+            turns.append({
+                "index": idx,
+                "user": user_text,
+                "assistant": _truncate(assistant_text),
+            })
+        else:
+            i += 1
+
+    return turns
+
+
+def build_output(filepath, turns):
+    """Build the standard conversation-dump JSON structure."""
+    path = Path(filepath)
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        timestamp = mtime.isoformat()
+    except OSError:
+        timestamp = ""
+
+    return {
+        "source": "md-import",
+        "session_id": path.stem,
+        "timestamp": timestamp,
+        "turns": turns,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Parse .md dialog files into conversation-dump JSON format"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # parse subcommand
+    parse_p = sub.add_parser("parse", help="Parse a single .md file")
+    parse_p.add_argument("file", help="Path to the .md dialog file")
+
+    # list subcommand
+    list_p = sub.add_parser("list", help="List .md dialog files in a directory")
+    list_p.add_argument("directory", help="Directory to scan for .md files")
+
+    # batch subcommand
+    batch_p = sub.add_parser("batch", help="Parse all .md files in a directory")
+    batch_p.add_argument("directory", help="Directory containing .md files")
+    batch_p.add_argument("--outdir", help="Output directory for JSON files")
+
+    args = parser.parse_args()
+
+    if args.command == "parse":
+        segments = parse_md_file(args.file)
+        turns = segments_to_turns(segments)
+        output = build_output(args.file, turns)
+        json.dump(output, sys.stdout, indent=2, ensure_ascii=False)
+        print()
+
+    elif args.command == "list":
+        directory = Path(args.directory)
+        if not directory.is_dir():
+            print(f"Not a directory: {directory}", file=sys.stderr)
+            sys.exit(1)
+        md_files = sorted(directory.glob("*.md"))
+        for i, f in enumerate(md_files, 1):
+            segments = parse_md_file(f)
+            turns = segments_to_turns(segments)
+            print(f"[{i}] {f.name} | {len(turns)} turns")
+
+    elif args.command == "batch":
+        directory = Path(args.directory)
+        outdir = Path(args.outdir) if args.outdir else directory
+        outdir.mkdir(parents=True, exist_ok=True)
+
+        md_files = sorted(directory.glob("*.md"))
+        for f in md_files:
+            segments = parse_md_file(f)
+            turns = segments_to_turns(segments)
+            if not turns:
+                continue
+            output = build_output(f, turns)
+            out_path = outdir / f"{f.stem}.json"
+            out_path.write_text(
+                json.dumps(output, indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            print(f"Wrote {out_path} ({len(turns)} turns)")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/import-dialog/SKILL.md
+++ b/skills/import-dialog/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: import-dialog
+description: Import .md dialog files (Claude.ai exports, custom markdown conversations) to create or update advisor profiles. Use when the user wants to import a conversation file, update an advisor with new dialog data, or add .md chat history to the advisor library. Invoked with /import-dialog.
+---
+
+# Import Dialog — Update Advisor from .md Files
+
+Import exported markdown dialog files and use them to create or update an advisor profile through the conversation-dump and soul-extraction pipeline.
+
+## Phase 1 — Specify Inputs
+
+Ask the user for:
+
+1. **File path(s):** One or more `.md` dialog files to import. Accept glob patterns (e.g., `docs/*.md`).
+2. **Target advisor:** An existing advisor slug (from `advisors/index.md`) or a new advisor name. If new, also gather background info (field, themes, skills) for the profile header.
+
+## Phase 2 — Parse and Store
+
+Run the bundled parser to convert `.md` files into standard JSON turns:
+
+```bash
+python3 <skill-base-dir>/../conversation-dump/parse_md_dialog.py parse <file.md>
+```
+
+For multiple files:
+
+```bash
+python3 <skill-base-dir>/../conversation-dump/parse_md_dialog.py batch <directory> --outdir docs/dialog/md-import/raw/
+```
+
+Save JSON outputs to `docs/dialog/md-import/raw/`. Verify each file parsed correctly (non-zero turns).
+
+## Phase 3 — Classify and Analyze
+
+Follow `conversation-dump` Phases 2–3:
+
+1. **Classify** each session into a topic using the standard taxonomy: `skill-design`, `debugging`, `documentation`, `refactoring`, `feature-implementation`, `paper-review`, `research-brainstorming`, `data-analysis`, `system-design`, `testing`, `code-review`, `literature-survey`, `writing`, `automated`, `other`.
+
+2. Move classified sessions to `docs/dialog/md-import/<topic>/`.
+
+3. Present topic counts to the user. Ask which topics to analyze in depth.
+
+4. **Deep analysis:** For each selected topic, tag every user message across the six dimensions (`bloom`, `depth`, `probe`, `presup`, `discourse`, `mechanism`). Save enriched JSON to `docs/dialog/md-import/<topic>/`.
+
+## Phase 4 — Soul Extraction
+
+For each selected topic, follow `soul-extraction` Phases 2–4:
+
+1. **Extract patterns:** Identify trigger→reaction pairs. Cluster similar turns (3-of-4 dimension match). Record patterns with frequency and examples.
+
+2. **Detect logic jumps:** Find user messages that are not direct responses to the assistant's prior turn. Curate the 5–12 most valuable. Present each candidate to the user for confirmation with causality chain options.
+
+3. **Output:** Write `thinking-pattern.md` and `master-thinking.md` to `docs/dialog/md-import/<topic>/`.
+
+## Phase 5 — Update Advisor Profile
+
+Read the target advisor's existing `advisors/<slug>/profile.md`.
+
+**If advisor exists:**
+- Preserve the Background section (unless user provides updates).
+- For each topic with sufficient data (2+ patterns), generate the five thinking-style subsections: Cognitive Style, Attention Patterns, Reasoning Strengths, Conversation Dynamics, Potential Blind Spots.
+- Add new topic sections or replace existing ones that were re-analyzed.
+- Keep existing topic sections that were not re-analyzed.
+
+**If advisor is new:**
+- Create `advisors/<slug>/profile.md` with Background + topic sections.
+- Create `advisors/<slug>/` directory.
+
+**Update `advisors/index.md`** — add or update the row for this advisor.
+
+Present the updated profile to the user for review:
+> Your advisor profile has been updated at `advisors/<slug>/profile.md`. The new analysis added/updated the following topic sections: [list]. Please review — raw dialog data stays in `docs/dialog/md-import/` and is not included in the profile.
+
+## Supported .md Formats
+
+The parser (`parse_md_dialog.py`) auto-detects these role marker patterns:
+
+| Format | Human marker | Assistant marker |
+|--------|-------------|-----------------|
+| Claude.ai export | `## **Human**` | `## **Claude**` |
+| Bold variant | `## **User**` | `## **Assistant**` |
+| Plain heading | `## Human` | `## Claude` or `## Assistant` |
+| Colon format | `**Human:**` | `**Claude:**` or `**Assistant:**` |
+
+Messages are separated by `---` lines (ignored during parsing). Nested markdown headings within assistant responses are preserved as content.

--- a/skills/incarnate/SKILL.md
+++ b/skills/incarnate/SKILL.md
@@ -26,13 +26,39 @@ Hold this information for Step 4.
 
 ### Step 2 — Conversation Analysis
 
-Ask the contributor to specify their conversation source: **claude** or **codex**.
+Ask the contributor to specify their conversation source:
 
-Run the analysis pipeline step by step:
+- **(a)** Claude Code / Codex CLI (JSONL session logs)
+- **(b)** Exported `.md` dialog files (Claude.ai web exports, custom markdown conversations)
+- **(c)** Both — import `.md` files first, then scan JSONL logs, merge all data
 
-**Step 2a — conversation-dump.** Read `skills/conversation-dump/SKILL.md` and follow Phases 1-4. This extracts all sessions, classifies them by topic, performs deep 6-dimension analysis, and outputs tagged JSON reports. At the end of Phase 2, the contributor selects which topics to analyze in depth.
+Run the analysis pipeline based on the chosen source:
 
-**Step 2b — soul-extraction (per topic).** For each topic the contributor selected, read `skills/soul-extraction/SKILL.md` and follow Phases 1-4. Skip soul-extraction's Phase 1 source/topic prompt — you already know both from conversation-dump. Pass the source and topic directly. The contributor participates in the logic jump confirmation gate — this is their opportunity to explain their own reasoning. Do not skip or rush it.
+**If (a) — JSONL sessions:**
+
+**Step 2a — conversation-dump.** Read `skills/conversation-dump/SKILL.md` and follow Phases 1–4. This extracts all sessions, classifies them by topic, performs deep 6-dimension analysis, and outputs tagged JSON reports. At the end of Phase 2, the contributor selects which topics to analyze in depth.
+
+**If (b) — .md dialog files:**
+
+**Step 2a — parse .md files.** Ask the contributor for the file path(s). Run the markdown parser:
+
+```bash
+python3 skills/conversation-dump/parse_md_dialog.py parse <file.md>
+```
+
+For multiple files in a directory:
+
+```bash
+python3 skills/conversation-dump/parse_md_dialog.py batch <directory> --outdir docs/dialog/md-import/raw/
+```
+
+Save JSON outputs to `docs/dialog/md-import/raw/`. Then follow conversation-dump Phases 2–3 (classify by topic, deep 6-dimension analysis) on the parsed JSON files.
+
+**If (c) — both sources:**
+
+Run the .md import first (Step 2a for option b), then the JSONL extraction (Step 2a for option a). Merge all classified sessions before presenting topic counts. Sessions from different sources in the same topic are analyzed together.
+
+**Step 2b — soul-extraction (per topic).** For each topic the contributor selected, read `skills/soul-extraction/SKILL.md` and follow Phases 1–4. Skip soul-extraction's Phase 1 source/topic prompt — you already know both from conversation-dump. Pass the source and topic directly. The contributor participates in the logic jump confirmation gate. Do not skip or rush it.
 
 After soul-extraction finishes for all selected topics, note which topics had enough data to produce patterns (2+ patterns = sufficient).
 
@@ -62,35 +88,24 @@ How does this person steer conversations?
 What does this person *not* do? Frame constructively — these are tendencies, not flaws.
 - **Derived from:** absent or rare tags across patterns, plus per-turn `presup` tags from the conversation-dump JSON files
 
-For presup-derived blind spots: read the per-turn `presup` tags directly from the session JSON files in `docs/dialog/<source>/<topic>/`. Count non-sound presuppositions (existential-gap, factive-gap, loaded, ambiguous, missing-context, leading). If a specific presup issue appears 3+ times across sessions, generate a directive about it. For example, frequent `presup:ambiguous` → "As this advisor, you sometimes use imprecise framing — 'make it better' rather than specifying what 'better' means."
+For presup-derived blind spots: read the per-turn `presup` tags directly from the session JSON files in `docs/dialog/<source>/<topic>/`. Count non-sound presuppositions. If a specific presup issue appears 3+ times across sessions, generate a directive about it.
 
 **Directive rules:**
 
-Each subsection contains a narrative paragraph followed by one or more directives:
+Each subsection contains a narrative paragraph followed by directives:
 
 ```markdown
 **As this advisor:** <how to behave when role-playing this person>
 **Evidence:** <pattern or jump reference>
 ```
 
-For pattern-derived directives:
-```
-**Evidence:** Pattern "<name>" (Nx across M sessions) — "<example quote>"
-```
-
-For jump-derived directives:
-```
-**Evidence:** Logic jump "<title>" — `<causality chain>`
-```
-
-- **5-15 directives per topic section.** Fewer than 5 = data too thin (warn contributor). More than 15 = prioritize by frequency and impact.
+- **5–15 directives per topic section.** Fewer than 5 = data too thin (warn contributor).
 - Every directive must be grounded in at least one pattern or logic jump. No speculative directives.
-- Directives describe how the advisor **would behave**, not what a mentor should do for them:
-  - Good: "As this advisor, challenge naming inconsistencies immediately — precision in terminology reflects precision in thinking."
+- Directives describe how the advisor **would behave**, not what a mentor should do:
+  - Good: "As this advisor, challenge naming inconsistencies immediately."
   - Bad: "Be precise with terminology around this user."
 - Blind spot directives describe tendencies authentically:
-  - Good: "As this advisor, you tend to follow your reasoning chains without pausing for empirical evidence. Role-play this authentically — but if asked for evidence, be honest about what you're inferring vs. what's established."
-  - Bad: "This advisor doesn't check evidence enough."
+  - Good: "As this advisor, you tend to follow reasoning chains without pausing for empirical evidence. Role-play this authentically — but if asked for evidence, be honest about what you're inferring vs. what's established."
 
 ### Step 4 — Output
 
@@ -112,45 +127,21 @@ For jump-derived directives:
 ## Thinking Style: <topic>
 
 ### Cognitive Style
-
 <narrative>
-
 **As this advisor:** <directive>
 **Evidence:** <reference>
 
 ### Attention Patterns
-
-<narrative>
-
-**As this advisor:** <directive>
-**Evidence:** <reference>
+...
 
 ### Reasoning Strengths
-
-<narrative>
-
-**As this advisor:** <directive>
-**Evidence:** <reference>
+...
 
 ### Conversation Dynamics
-
-<narrative>
-
-**As this advisor:** <directive>
-**Evidence:** <reference>
+...
 
 ### Potential Blind Spots
-
-<narrative>
-
-**As this advisor:** <directive>
-**Evidence:** <reference>
-
----
-
-## Thinking Style: <another topic>
-
-(same subsections)
+...
 ```
 
 **Update the advisor index** at `advisors/index.md` — add or update a row for this contributor:
@@ -159,8 +150,7 @@ For jump-derived directives:
 | <Name> | <Field> | <Top 2-3 strengths> | <topic1, topic2, ...> |
 ```
 
-If `advisors/index.md` does not exist, create it with the header:
-
+If `advisors/index.md` does not exist, create it with header:
 ```markdown
 # Advisor Library
 
@@ -168,13 +158,12 @@ If `advisors/index.md` does not exist, create it with the header:
 |------|-------|-----------|--------|
 ```
 
-**Present to contributor for review:**
-
+**Present to contributor for review** after writing:
 > Your advisor profile is ready at `advisors/<slug>/profile.md`. Please review it — you can edit anything before it's shared. The raw conversation data stays in `docs/dialog/` (gitignored) and is never included in the profile.
 
 ### Updating an Existing Profile
 
-When run on a contributor who already has a profile (`advisors/<slug>/profile.md` exists):
+When run on a contributor who already has a profile:
 
 1. Read the existing profile
 2. Preserve the Background section (unless the contributor provides updated info)


### PR DESCRIPTION
Add the ability to import exported markdown dialog files (Claude.ai web exports, custom markdown conversations) as a data source for creating and updating advisor profiles.

Changes:
- New parse_md_dialog.py script that converts .md dialog files to the standard conversation-dump JSON format, with auto-detection of 4 role marker formats
- New import-dialog skill providing a standalone /import-dialog command with a 5-phase workflow
- Extended incarnate skill Step 2 to accept .md files as a third data source option alongside JSONL logs

Note: This change is done by a Claude Code agent.