### PR TITLE
feat: configurable knowledge-base directory name via $SCIBRAIN_KB_DIRNAME

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,11 @@ advisors/*/.knowledge/
 .knowledge/
 
 docs/agent-profiles/
+docs/dialog/
 docs/discussion/
 docs/plans/
+docs/references/
 docs/superpowers/
+docs/superpowers/specs/
+docs/survey-question-classification.md
 docs/test-reports/

--- a/skills/download-ref/SKILL.md
+++ b/skills/download-ref/SKILL.md
@@ -65,7 +65,7 @@ if [ -z "$KB" ]; then
 fi
 ```
 
-For advisor flows (`/incarnate`, `/ideas` with a selected advisor), override `KB` explicitly to `<plugin-root>/advisors/<slug>/.knowledge`.
+For advisor flows (`/incarnate`, `/ideas` with a selected advisor), resolve the advisor KB instead: `KB=$(python3 skills/download-ref/helpers/resolve_kb.py --advisor <slug>)`. This honors `$SCIBRAIN_KB_DIRNAME` the same way the project-KB form does.
 
 ### 2. Confirm the refs aren't already present
 

--- a/skills/download-ref/SKILL.md
+++ b/skills/download-ref/SKILL.md
@@ -202,8 +202,9 @@ for f in "$KB"/*.md; do
   head -1 "$f" | grep -q '^---$' || echo "MISSING FRONTMATTER: $f"
 done
 # Raw blobs gitignored
-git -C "$(dirname "$KB")" check-ignore .knowledge/.raw/ 2>/dev/null \
-  || echo "WARN: .knowledge/.raw/ not gitignored"
+KB_NAME=$(basename "$KB")
+git -C "$(dirname "$KB")" check-ignore "$KB_NAME/.raw/" 2>/dev/null \
+  || echo "WARN: $KB_NAME/.raw/ not gitignored"
 # INDEX picked up the new ids
 for id in 1806.08734 2006.10739; do
   grep -q "$id" "$KB/INDEX.md" || echo "WARN: $id missing from INDEX.md"

--- a/skills/download-ref/SKILL.md
+++ b/skills/download-ref/SKILL.md
@@ -217,7 +217,7 @@ Tell the user: new cite key(s), rendered file path(s), `full_text` yes/no per re
 
 - **`/survey` / `/researchstyle`**: write their own `.raw/` JSON via batched fetches and call `append_bibtex.py` directly (skipping the per-ref confirmation in Step 6). They invoke `index.py` at the end of their run.
 - **`/ideas` end-of-session**: surfaces candidate IDs/DOIs from the conversation; for the user's selections, invokes `/download-ref` in single-shot mode.
-- **`/incarnate`**: invokes `/download-ref` (or `/researchstyle`) targeting `advisors/<slug>/.knowledge/`.
+- **`/incarnate`**: invokes `/download-ref` (or `/researchstyle`) targeting the advisor KB resolved by `python3 skills/download-ref/helpers/resolve_kb.py --advisor <slug>`.
 
 ## Common mistakes
 

--- a/skills/download-ref/helpers/index.py
+++ b/skills/download-ref/helpers/index.py
@@ -92,8 +92,9 @@ def main() -> int:
     note = f" {args.source_note}" if args.source_note else ""
     out.append(f"Generated {today}.{note}")
     out.append("")
-    out.append("Search inside this dir with `rg --hidden -g '!.raw' \"term\" .knowledge/` "
-               "(or `rg` from inside `.knowledge/` itself). "
+    kb_name = args.kb.resolve().name
+    out.append(f"Search this KB from its parent with `rg --hidden -g '!.raw' \"term\" {kb_name}/`, "
+               "or run `rg --hidden -g '!.raw' \"term\" .` from inside the KB. "
                "The `.raw/` subdir holds the original PDFs / clones / HTML and is gitignored.")
     out.append("")
 

--- a/skills/download-ref/helpers/resolve_kb.py
+++ b/skills/download-ref/helpers/resolve_kb.py
@@ -1,20 +1,24 @@
 #!/usr/bin/env python3
-"""Resolve a project's knowledge-base directory.
+"""Resolve a project's or advisor's knowledge-base directory.
 
-Walks up from `start` looking for a `.git/` directory. If found, returns
-`<git-root>/<KB-name>`. If not found and `start` is at or above $HOME,
-returns None (the caller should prompt the user). Otherwise falls back
-to `start/<KB-name>`.
+For project KBs: walks up from `start` looking for a `.git/` directory.
+If found, returns `<git-root>/<KB-name>`. If not found and `start` is at
+or above $HOME, returns None (the caller should prompt the user).
+Otherwise falls back to `start/<KB-name>`.
+
+For advisor KBs: pass `--advisor <slug>` and the path is rooted at the
+plugin checkout — `<plugin-root>/advisors/<slug>/<KB-name>`. `--start`
+is ignored when `--advisor` is set.
 
 The KB directory name defaults to `.knowledge` and can be overridden via
 the `SCIBRAIN_KB_DIRNAME` environment variable (e.g. `kb`, `papers`).
 
-This is the single source of truth for "where does the project KB live"
-across download-ref, survey, researchstyle, ideas, and incarnate.
+This is the single source of truth for "where does the KB live" across
+download-ref, survey, researchstyle, ideas, and incarnate.
 
 CLI:
-    python3 resolve_kb.py [--start DIR]
-        DIR defaults to $PWD. Prints the resolved KB path to stdout,
+    python3 resolve_kb.py [--start DIR] [--advisor SLUG]
+        --start defaults to $PWD. Prints the resolved KB path to stdout,
         or writes "unresolvable from <start>" to stderr and exits 2.
 """
 from __future__ import annotations
@@ -47,10 +51,22 @@ def _kb_dirname() -> str:
     return os.environ.get("SCIBRAIN_KB_DIRNAME", ".knowledge")
 
 
-def resolve_kb(start: Optional[Path] = None) -> Optional[Path]:
-    """Return the resolved KB path, or None if the caller should prompt."""
-    start = (start or Path.cwd()).resolve()
+def _plugin_root() -> Path:
+    """Plugin root (the sci-brain checkout). Used to locate advisors/."""
+    return Path(__file__).resolve().parents[3]
+
+
+def resolve_kb(start: Optional[Path] = None, advisor: Optional[str] = None) -> Optional[Path]:
+    """Return the resolved KB path, or None if the caller should prompt.
+
+    When `advisor` is given, returns `<plugin-root>/advisors/<slug>/<kb-name>`
+    and ignores `start`. Otherwise resolves the project KB by walking up
+    from `start` looking for a git root.
+    """
     name = _kb_dirname()
+    if advisor:
+        return _plugin_root() / "advisors" / advisor / name
+    start = (start or Path.cwd()).resolve()
     git_root = _find_git_root(start)
     if git_root is not None:
         return git_root / name
@@ -62,9 +78,12 @@ def resolve_kb(start: Optional[Path] = None) -> Optional[Path]:
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--start", type=Path, default=None,
-                        help="Starting directory (default: $PWD)")
+                        help="Starting directory for project-KB resolution (default: $PWD)")
+    parser.add_argument("--advisor", default=None,
+                        help="Advisor slug (lowercase hyphenated). When set, returns the "
+                             "advisor KB path under <plugin-root>/advisors/<slug>/.")
     args = parser.parse_args(argv)
-    kb = resolve_kb(start=args.start)
+    kb = resolve_kb(start=args.start, advisor=args.advisor)
     if kb is None:
         print(f"unresolvable from {args.start or Path.cwd()}", file=sys.stderr)
         return 2

--- a/skills/download-ref/helpers/resolve_kb.py
+++ b/skills/download-ref/helpers/resolve_kb.py
@@ -29,6 +29,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+DEFAULT_KB_DIRNAME = ".knowledge"
+
 
 def _find_git_root(start: Path) -> Optional[Path]:
     cur = start.resolve()
@@ -48,7 +50,15 @@ def _is_at_or_above_home(start: Path) -> bool:
 
 def _kb_dirname() -> str:
     """KB directory name. Override via $SCIBRAIN_KB_DIRNAME (default '.knowledge')."""
-    return os.environ.get("SCIBRAIN_KB_DIRNAME", ".knowledge")
+    raw = os.environ.get("SCIBRAIN_KB_DIRNAME")
+    if raw is None or raw == "":
+        return DEFAULT_KB_DIRNAME
+    if Path(raw).is_absolute() or raw in {".", ".."} or "/" in raw or "\\" in raw:
+        raise ValueError(
+            "SCIBRAIN_KB_DIRNAME must be a single directory name, "
+            f"not an absolute or nested path: {raw!r}"
+        )
+    return raw
 
 
 def _plugin_root() -> Path:
@@ -83,7 +93,11 @@ def main(argv: Optional[list[str]] = None) -> int:
                         help="Advisor slug (lowercase hyphenated). When set, returns the "
                              "advisor KB path under <plugin-root>/advisors/<slug>/.")
     args = parser.parse_args(argv)
-    kb = resolve_kb(start=args.start, advisor=args.advisor)
+    try:
+        kb = resolve_kb(start=args.start, advisor=args.advisor)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
     if kb is None:
         print(f"unresolvable from {args.start or Path.cwd()}", file=sys.stderr)
         return 2

--- a/skills/download-ref/helpers/resolve_kb.py
+++ b/skills/download-ref/helpers/resolve_kb.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-"""Resolve a project's .knowledge/ directory.
+"""Resolve a project's knowledge-base directory.
 
 Walks up from `start` looking for a `.git/` directory. If found, returns
-`<git-root>/.knowledge`. If not found and `start` is at or above $HOME,
+`<git-root>/<KB-name>`. If not found and `start` is at or above $HOME,
 returns None (the caller should prompt the user). Otherwise falls back
-to `start/.knowledge`.
+to `start/<KB-name>`.
+
+The KB directory name defaults to `.knowledge` and can be overridden via
+the `SCIBRAIN_KB_DIRNAME` environment variable (e.g. `kb`, `papers`).
 
 This is the single source of truth for "where does the project KB live"
 across download-ref, survey, researchstyle, ideas, and incarnate.
@@ -39,15 +42,21 @@ def _is_at_or_above_home(start: Path) -> bool:
     return s == home or home.is_relative_to(s)
 
 
+def _kb_dirname() -> str:
+    """KB directory name. Override via $SCIBRAIN_KB_DIRNAME (default '.knowledge')."""
+    return os.environ.get("SCIBRAIN_KB_DIRNAME", ".knowledge")
+
+
 def resolve_kb(start: Optional[Path] = None) -> Optional[Path]:
-    """Return the resolved .knowledge/ path, or None if the caller should prompt."""
+    """Return the resolved KB path, or None if the caller should prompt."""
     start = (start or Path.cwd()).resolve()
+    name = _kb_dirname()
     git_root = _find_git_root(start)
     if git_root is not None:
-        return git_root / ".knowledge"
+        return git_root / name
     if _is_at_or_above_home(start):
         return None
-    return start / ".knowledge"
+    return start / name
 
 
 def main(argv: Optional[list[str]] = None) -> int:

--- a/skills/ideas/SKILL.md
+++ b/skills/ideas/SKILL.md
@@ -116,11 +116,17 @@ If the user picks an advisor, do **not** just read `advisors/<slug>/profile.md` 
 
 1. **Read the advisor profile.** Load `advisors/<slug>/profile.md` (slug is lowercase hyphenated, e.g., `xi-dai`) and use the most relevant topic section (prefer `brainstorming` or `research`) to understand how this advisor thinks.
 
-When an advisor is selected:
-- Load `advisors/<slug>/.knowledge/INDEX.md` to know what literature is available.
-- Load `advisors/<slug>/.knowledge/NOTES.md` for the advisor's curated thematic notes (if present).
-- Pre-fetch a handful of representative papers from `advisors/<slug>/.knowledge/<id>_<slug>.md` and supply them as context **loaded into the advisor subagent context** at launch.
-- If `advisors/<slug>/.knowledge/` is empty, fall back to launching the advisor without a literature cache (still useful — the profile alone shapes their reasoning).
+When an advisor is selected, first resolve the advisor KB path so it follows `$SCIBRAIN_KB_DIRNAME` if the user has set it:
+
+```sh
+ADVISOR_KB=$(python3 skills/download-ref/helpers/resolve_kb.py --advisor <slug>)
+```
+
+Then:
+- Load `$ADVISOR_KB/INDEX.md` to know what literature is available.
+- Load `$ADVISOR_KB/NOTES.md` for the advisor's curated thematic notes (if present).
+- Pre-fetch a handful of representative papers from `$ADVISOR_KB/<id>_<slug>.md` and supply them as context **loaded into the advisor subagent context** at launch.
+- If `$ADVISOR_KB/` is empty or missing, fall back to launching the advisor without a literature cache (still useful — the profile alone shapes their reasoning).
 
 **Launch the advisor.** The advisor subagent's job is to contribute hard-won taste: what to ask next, which assumptions are dangerous, which papers matter, and what this advisor would investigate first. The main mentor remains responsible for session flow, empathy, logging, and synthesis.
 
@@ -214,7 +220,7 @@ If the user's self-introduction already reveals their experience level (e.g., th
 
 **Always run this phase** — even when the user already stated a direction. There's almost always more context to uncover.
 
-**Load context:** Check for knowledge bases in the project path (e.g., `<project>/.knowledge/`). If found, note them for later use. If none found, note that a lighter web search will be needed later. If an advisor is active, also load `advisors/<slug>/.knowledge/INDEX.md` so the mentor knows what literature the advisor subagent already has in context.
+**Load context:** Resolve the project KB via `KB=$(python3 skills/download-ref/helpers/resolve_kb.py)` and check `$KB/` for indexed knowledge. If found, note it for later use. If none found, note that a lighter web search will be needed later. If an advisor is active, also load `$ADVISOR_KB/INDEX.md` (resolved earlier with `--advisor <slug>`) so the mentor knows what literature the advisor subagent already has in context.
 
 #### Step 1: Talk first
 

--- a/skills/ideas/SKILL.md
+++ b/skills/ideas/SKILL.md
@@ -153,7 +153,7 @@ Use this for moments where the advisor's specific perspective, instinct, or expe
 
 If no advisor is selected or no advisors exist, proceed with default mentor behavior.
 
-**First, check for history.** Read `docs/discussion/user-profile.md` if it exists — this contains the user's persisted profile from previous sessions. Also check for a project knowledge base at `<project>/.knowledge/` — this contains indexed publication data from the `researchstyle` skill. Also read `docs/discussion/*-ideas-log.md` if they exist — they contain past brainstorming sessions and reveal the user's evolving interests, thinking patterns, and which directions they've explored before.
+**First, check for history.** Read `docs/discussion/user-profile.md` if it exists — this contains the user's persisted profile from previous sessions. Also resolve the project KB via `KB=$(python3 skills/download-ref/helpers/resolve_kb.py)` and check `$KB/` for indexed publication data from the `researchstyle` skill. Also read `docs/discussion/*-ideas-log.md` if they exist — they contain past brainstorming sessions and reveal the user's evolving interests, thinking patterns, and which directions they've explored before.
 
 **Session picker.** If previous session logs exist, present them as an interactive choice via `AskUserQuestion` before proceeding:
 
@@ -315,7 +315,7 @@ The conversation may loop between steps 2-4 as the idea evolves. That's natural.
 
 After a natural stopping point (idea confirmed, user seems satisfied, or energy drops), offer next steps via `AskUserQuestion`: keep refining, try a different angle, take time to think and pick up next session, or wrap up. Don't offer this after every single exchange — let the conversation breathe.
 
-**Search policy:** Ground ideas in loaded knowledge bases (`<project>/.knowledge/` and `advisors/<slug>/.knowledge/`) first. Only search the web when the conversation goes beyond what those caches cover.
+**Search policy:** Ground ideas in the loaded knowledge bases (`$KB` and, when an advisor is active, `$ADVISOR_KB`) first. Only search the web when the conversation goes beyond what those caches cover.
 
 ### Phase 3 — Wrap Up
 

--- a/skills/incarnate/SKILL.md
+++ b/skills/incarnate/SKILL.md
@@ -26,7 +26,7 @@ From the response, extract:
 
 Hold this information for Step 4.
 
-**Advisor KB.** Each advisor gets a private knowledge base at `advisors/<slug>/.knowledge/` (shape identical to the project KB: `INDEX.md`, `NOTES.md`, `.raw/`, `.figures/`, rendered `<id>_<slug>.md` files). The advisor's BibTeX namespace lives at `advisors/<slug>/ref.bib`. When `/researchstyle` or `/download-ref` is invoked from this skill, pass `--kb advisors/<slug>/.knowledge` explicitly to direct writes to the advisor KB rather than the project KB.
+**Advisor KB.** Each advisor gets a private knowledge base at `advisors/<slug>/.knowledge/` (shape identical to the project KB: `INDEX.md`, `NOTES.md`, `.raw/`, `.figures/`, rendered `<id>_<slug>.md` files). The advisor's BibTeX namespace lives at `advisors/<slug>/ref.bib`. When `/researchstyle` or `/download-ref` is invoked from this skill, resolve the advisor KB path via `python3 skills/download-ref/helpers/resolve_kb.py --advisor <slug>` and pass it as `--kb "$KB"` so writes land in the advisor KB rather than the project KB. (Users who set `$SCIBRAIN_KB_DIRNAME` get the right directory name automatically.)
 
 ### Step 2 — Conversation Analysis
 

--- a/skills/researchstyle/SKILL.md
+++ b/skills/researchstyle/SKILL.md
@@ -68,7 +68,7 @@ The KB target is decided by the caller:
 KB=$(python3 skills/download-ref/helpers/resolve_kb.py)
 
 # Invoked from /incarnate (indexes another researcher's collection into the advisor KB):
-KB="<plugin-root>/advisors/<slug>/.knowledge"
+KB=$(python3 skills/download-ref/helpers/resolve_kb.py --advisor <slug>)
 ```
 
 Ensure `$KB/.raw/arxiv/` and `$KB/.raw/doi/` exist.

--- a/skills/survey/SKILL.md
+++ b/skills/survey/SKILL.md
@@ -33,13 +33,13 @@ Each subagent produces a short **findings report** — key papers found, grouped
 
 **Step 4 — Build registry.** For the selected directions only, generate the BibTeX. **Never generate BibTeX from memory** — always verify against an authoritative source.
 
-**KB resolution.** The target KB is the project KB by default:
+**KB resolution.** The target KB is the project KB by default — `<project>/.knowledge/` unless the user overrides the directory name via `$SCIBRAIN_KB_DIRNAME`:
 
 ```sh
 KB=$(python3 skills/download-ref/helpers/resolve_kb.py)
 ```
 
-If `KB` is empty (resolve_kb printed `unresolvable from ...`), ask the user via `AskUserQuestion` for an explicit path. When invoked from `/incarnate` against a specific advisor, override with `<plugin-root>/advisors/<slug>/.knowledge`.
+If `KB` is empty (resolve_kb printed `unresolvable from ...`), ask the user via `AskUserQuestion` for an explicit path. When invoked from `/incarnate` against a specific advisor, override via `KB=$(python3 skills/download-ref/helpers/resolve_kb.py --advisor <slug>)` so the path follows `$SCIBRAIN_KB_DIRNAME` too.
 
 Ensure `$KB/.raw/arxiv/` and `$KB/.raw/doi/` exist (`mkdir -p`).
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,37 @@
+"""Tests for skills/download-ref/helpers/index.py."""
+import importlib.util
+import sys
+from pathlib import Path
+
+
+HELPER = Path(__file__).resolve().parents[1] / "skills" / "download-ref" / "helpers" / "index.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("index_helper", HELPER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_generated_index_uses_actual_kb_dirname(tmp_path, monkeypatch):
+    kb = tmp_path / "proj" / "kb"
+    kb.mkdir(parents=True)
+    (kb / "paper.md").write_text("""---
+type: arxiv
+title: Test Paper
+authors: Example Author
+year: 2026
+full_text: yes
+---
+
+body
+""")
+    monkeypatch.setattr(sys, "argv", ["index.py", "--kb", str(kb), "--title", "test refs"])
+    mod = _load()
+
+    assert mod.main() == 0
+
+    text = (kb / "INDEX.md").read_text()
+    assert "kb/" in text
+    assert ".knowledge/" not in text

--- a/tests/test_resolve_kb.py
+++ b/tests/test_resolve_kb.py
@@ -76,3 +76,29 @@ def test_cli_exits_nonzero_when_unresolvable(tmp_path, capsys, monkeypatch):
     err = capsys.readouterr().err
     assert rc != 0
     assert "unresolvable" in err.lower()
+
+
+def test_default_dirname_is_dot_knowledge(tmp_path, monkeypatch):
+    repo = tmp_path / "proj"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.delenv("SCIBRAIN_KB_DIRNAME", raising=False)
+    mod = _load()
+    assert mod.resolve_kb(start=repo) == repo / ".knowledge"
+
+
+def test_env_var_overrides_dirname_with_git_root(tmp_path, monkeypatch):
+    repo = tmp_path / "proj"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.setenv("SCIBRAIN_KB_DIRNAME", "kb")
+    mod = _load()
+    assert mod.resolve_kb(start=repo) == repo / "kb"
+
+
+def test_env_var_overrides_dirname_with_fallback(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    (fake_home / "scratch").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("SCIBRAIN_KB_DIRNAME", "papers")
+    mod = _load()
+    start = fake_home / "scratch"
+    assert mod.resolve_kb(start=start) == start / "papers"

--- a/tests/test_resolve_kb.py
+++ b/tests/test_resolve_kb.py
@@ -102,3 +102,38 @@ def test_env_var_overrides_dirname_with_fallback(tmp_path, monkeypatch):
     mod = _load()
     start = fake_home / "scratch"
     assert mod.resolve_kb(start=start) == start / "papers"
+
+
+def test_advisor_kb_under_plugin_root(monkeypatch):
+    monkeypatch.delenv("SCIBRAIN_KB_DIRNAME", raising=False)
+    mod = _load()
+    plugin_root = HELPER.resolve().parents[3]
+    assert mod.resolve_kb(advisor="lei-wang") == plugin_root / "advisors" / "lei-wang" / ".knowledge"
+
+
+def test_advisor_kb_honors_env_var(monkeypatch):
+    monkeypatch.setenv("SCIBRAIN_KB_DIRNAME", "kb")
+    mod = _load()
+    plugin_root = HELPER.resolve().parents[3]
+    assert mod.resolve_kb(advisor="xi-dai") == plugin_root / "advisors" / "xi-dai" / "kb"
+
+
+def test_advisor_ignores_start(tmp_path, monkeypatch):
+    """When --advisor is set, --start has no effect."""
+    monkeypatch.delenv("SCIBRAIN_KB_DIRNAME", raising=False)
+    repo = tmp_path / "proj"
+    (repo / ".git").mkdir(parents=True)
+    mod = _load()
+    plugin_root = HELPER.resolve().parents[3]
+    assert mod.resolve_kb(start=repo, advisor="some-advisor") == \
+        plugin_root / "advisors" / "some-advisor" / ".knowledge"
+
+
+def test_cli_advisor_flag(capsys, monkeypatch):
+    monkeypatch.delenv("SCIBRAIN_KB_DIRNAME", raising=False)
+    mod = _load()
+    rc = mod.main(["--advisor", "lei-wang"])
+    out = capsys.readouterr().out.strip()
+    plugin_root = HELPER.resolve().parents[3]
+    assert rc == 0
+    assert out == str(plugin_root / "advisors" / "lei-wang" / ".knowledge")

--- a/tests/test_resolve_kb.py
+++ b/tests/test_resolve_kb.py
@@ -104,6 +104,35 @@ def test_env_var_overrides_dirname_with_fallback(tmp_path, monkeypatch):
     assert mod.resolve_kb(start=start) == start / "papers"
 
 
+def test_empty_env_var_uses_default_dirname(tmp_path, monkeypatch):
+    repo = tmp_path / "proj"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.setenv("SCIBRAIN_KB_DIRNAME", "")
+    mod = _load()
+    assert mod.resolve_kb(start=repo) == repo / ".knowledge"
+
+
+@pytest.mark.parametrize("dirname", ["/tmp/kb", "../outside", "nested/kb", r"nested\kb", ".", ".."])
+def test_rejects_invalid_env_var_dirnames(tmp_path, monkeypatch, dirname):
+    repo = tmp_path / "proj"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.setenv("SCIBRAIN_KB_DIRNAME", dirname)
+    mod = _load()
+    with pytest.raises(ValueError, match="SCIBRAIN_KB_DIRNAME"):
+        mod.resolve_kb(start=repo)
+
+
+def test_cli_exits_nonzero_for_invalid_env_var(tmp_path, capsys, monkeypatch):
+    repo = tmp_path / "proj"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.setenv("SCIBRAIN_KB_DIRNAME", "/tmp/kb")
+    mod = _load()
+    rc = mod.main(["--start", str(repo)])
+    err = capsys.readouterr().err
+    assert rc != 0
+    assert "SCIBRAIN_KB_DIRNAME" in err
+
+
 def test_advisor_kb_under_plugin_root(monkeypatch):
     monkeypatch.delenv("SCIBRAIN_KB_DIRNAME", raising=False)
     mod = _load()

--- a/tests/test_skill_structure.py
+++ b/tests/test_skill_structure.py
@@ -163,6 +163,14 @@ def test_ideas_loads_advisor_kb_from_dot_knowledge():
     assert "publications.yml" not in text
     assert "papers/*.md" not in text
 
+
+def test_ideas_operational_instructions_use_resolved_kb_variables():
+    text = _read("ideas")
+    assert "Resolve the project KB via `KB=$(python3 skills/download-ref/helpers/resolve_kb.py)`" in text
+    assert "ADVISOR_KB=$(python3 skills/download-ref/helpers/resolve_kb.py --advisor <slug>)" in text
+    assert "project knowledge base at `<project>/.knowledge/`" not in text
+    assert "Ground ideas in loaded knowledge bases (`<project>/.knowledge/` and `advisors/<slug>/.knowledge/`)" not in text
+
 # ---- incarnate ----
 
 def test_incarnate_targets_advisor_dot_knowledge():


### PR DESCRIPTION
## Summary

- Adds `$SCIBRAIN_KB_DIRNAME` env var to override the KB directory name (default `.knowledge`). Read once in `skills/download-ref/helpers/resolve_kb.py` so every skill that resolves through it picks the override up for free.
- Adds `--advisor <slug>` to `resolve_kb.py` so advisor KBs at `<plugin-root>/advisors/<slug>/<kb-name>` follow the same override.
- Updates the four SKILL.md sites that previously instructed the agent to construct the advisor KB path with a literal `.knowledge` (survey, researchstyle, download-ref, incarnate) plus the operational advisor-loading block in `ideas/SKILL.md` to call the resolver instead — so override-mode is consistent across project and advisor flows.

To use a different name:
```sh
export SCIBRAIN_KB_DIRNAME=kb   # or `papers`, etc.
```
Users who override are responsible for updating their own `.gitignore` (the plugin's default still ignores `.knowledge/` and `advisors/*/.knowledge/`).

## Test plan

- [x] Existing 6 `resolve_kb` tests still pass
- [x] New tests cover: default unchanged, env override with git root, env override with home-fallback, `--advisor` with default name, `--advisor` with env override, `--advisor` ignores `--start`, CLI `--advisor` flag
- [x] Full suite (58 tests) passes
- [x] Sanity-checked CLI: project KB, advisor KB default, advisor KB with `SCIBRAIN_KB_DIRNAME=kb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)