### PR TITLE
Harden autoresearch with a neutral-atom end-to-end example

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -13,10 +13,13 @@ Enable the sci-brain skill in Codex via native skill discovery. Just clone and s
    git clone https://github.com/QuantumBFS/sci-brain.git ~/.codex/sci-brain
    ```
 
-2. **Create the skills symlink:**
+2. **Create one symlink per skill:**
    ```bash
-   mkdir -p ~/.agents/skills
-   ln -s ~/.codex/sci-brain/skills/sci-brain ~/.agents/skills/sci-brain
+   mkdir -p "$HOME/.agents/skills"
+   for skill in "$HOME/.codex/sci-brain/skills"/*; do
+     [ -f "$skill/SKILL.md" ] || continue
+     ln -sfn "$skill" "$HOME/.agents/skills/$(basename "$skill")"
+   done
    ```
 
 3. **Restart Codex** (quit and relaunch the CLI) to discover the skill.
@@ -24,10 +27,11 @@ Enable the sci-brain skill in Codex via native skill discovery. Just clone and s
 ## Verify
 
 ```bash
-ls -la ~/.agents/skills/sci-brain
+find "$HOME/.agents/skills" -maxdepth 1 -type l -print
 ```
 
-You should see a symlink pointing to the sci-brain skills directory.
+You should see one symlink for each directory under `sci-brain/skills/` that
+contains a `SKILL.md`.
 
 ## Updating
 
@@ -35,12 +39,15 @@ You should see a symlink pointing to the sci-brain skills directory.
 cd ~/.codex/sci-brain && git pull
 ```
 
-Skills update instantly through the symlink.
+Skills update instantly through the symlinks.
 
 ## Uninstalling
 
 ```bash
-rm ~/.agents/skills/sci-brain
+for skill in "$HOME/.codex/sci-brain/skills"/*; do
+  [ -f "$skill/SKILL.md" ] || continue
+  rm "$HOME/.agents/skills/$(basename "$skill")"
+done
 ```
 
 Optionally delete the clone: `rm -rf ~/.codex/sci-brain`.

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ docs/superpowers/
 docs/superpowers/specs/
 docs/survey-question-classification.md
 docs/test-reports/
+
+# Local git worktrees
+.worktrees/

--- a/docs/specs/2026-07-19-autoresearch-neutral-atom-smoke-test-design.md
+++ b/docs/specs/2026-07-19-autoresearch-neutral-atom-smoke-test-design.md
@@ -1,0 +1,265 @@
+# Neutral-atom autoresearch smoke test — design
+
+**Date:** 2026-07-19
+**Status:** User-approved design, pre-implementation
+**Target:** `QuantumBFS/sci-brain` autoresearch skill family
+**Research project:** `AtomicQCPlatformData`
+
+## Goal
+
+Exercise the complete autoresearch pipeline on a small, real neutral-atom
+dataset:
+
+1. choose and metricize a machine-checkable research topic;
+2. build the literature and implementation evidence base;
+3. build and self-test a sealed validator;
+4. run one autonomous research cycle with three attempts;
+5. use the observed friction to improve the skills;
+6. produce ten additional metricized topics suitable for undergraduate
+   training; and
+7. submit the validated skill changes as a pull request to
+   `QuantumBFS/sci-brain`.
+
+The smoke test is not allowed to claim that a total gate infidelity uniquely
+identifies a coherent error. It must preserve the project's distinction among
+estimable quantities, scenario bounds, and unidentifiable parameters.
+
+## Chosen smoke-test topic
+
+**Robust recovery of microwave Rabi frequency and envelope dynamics from a
+sparse processed population scan.**
+
+The source is the official CaltechDATA record
+`10.22002/4m9sp-yzr58`, specifically:
+
+- `fig4a_rabi_duration.npy`;
+- `fig4a_rabi_pop_1.npy`; and
+- `fig4a_rabi_pop_1_std.npy`.
+
+These three 768-byte arrays contain durations, processed state-\(|1\rangle\)
+populations, and one-standard-deviation uncertainties used for Fig. 4a of
+Manetsch et al., *Nature* 647, 60–67 (2025),
+DOI `10.1038/s41586-025-09641-4`.
+
+This is a processed-population inference task. It does not claim raw
+shot-level inversion.
+
+## Topic suitability
+
+| Criterion | Score | Rationale |
+|---|---:|---|
+| Checkable | 5 | A validator can compute held-out predictive error and reject invalid outputs. |
+| Cheap | 5 | Each fit uses tens of scalar observations and must finish within 30 seconds. |
+| Headroom | 4 | Attempts can vary envelope families, weighting, robust losses, parameterizations, and search strategies. |
+| Publishable | 3 | A single scan is a method smoke test, not a paper; the reusable bar is robust recovery under predefined sparse/noisy regimes. |
+
+## Approved metrics
+
+### Primary metric
+
+**Uncertainty-normalized held-out RMSE**, minimized:
+
+\[
+\operatorname{NRMSE}_{\sigma}
+=
+\sqrt{\frac{1}{N}
+\sum_i
+\left(\frac{\widehat p_i-p_i}{\max(\sigma_i,\sigma_{\min})}\right)^2}.
+\]
+
+The validator reports this scalar on development instances. The held-out query
+returns aggregate pass/fail only. The smoke-test goal is a development score
+below the trivial undamped-sinusoid baseline and a final held-out score below
+the threshold fixed in `research/validator/GOAL.md` before attempts begin.
+
+### Guard metrics
+
+- Every requested instance ID has exactly one finite prediction.
+- Every predicted population is in \([0,1]\).
+- The submitted Rabi frequency is positive and lies inside the predefined
+  physically plausible search interval.
+- The candidate passes unseen-instance and perturbed-grid checks; a lookup
+  table keyed by public row or instance IDs is rejected.
+- Runtime is at most 30 seconds per scored invocation.
+- Candidate execution has no network access and cannot read the private
+  benchmark or validator-private files.
+
+## Pipeline layout
+
+The smoke test runs in a clean, isolated git worktree derived from
+`AtomicQCPlatformData`. The current user worktree and its uncommitted files are
+not modified.
+
+The target project produces the standard suite artifacts:
+
+```text
+topics.md
+research/
+  STATE.md
+  CATALOG.md
+  INSIGHTS.md
+  database/
+  benchmark/
+    dev/
+    private/
+  validator/
+    GOAL.md
+    manifest.json
+    controls/
+docs/discussion/
+.knowledge/
+.worktrees/attempt-NNN/
+```
+
+The three source arrays are recorded with the CaltechDATA URL, DOI, file MD5,
+and acquisition date. Public source bytes are immutable inputs. A deterministic
+conversion step creates the visible development instances. A separate sealing
+step creates private perturbed-grid instances without printing their labels
+into the research-design context.
+
+## Evidence-base stage
+
+The evidence map covers:
+
+1. driven two-level population dynamics and parameter identifiability;
+2. damping/envelope model selection for Rabi oscillations;
+3. uncertainty-weighted and robust nonlinear fitting;
+4. leakage between model selection and held-out evaluation; and
+5. neutral-atom microwave-control inhomogeneity and coherent-control error.
+
+Each selected insight must cite a rendered reference in `.knowledge/INDEX.md`.
+For this smoke test, the user pre-authorized all five insight areas above as
+`## Selected`. The catalog must reproduce at least the trivial undamped
+baseline; other entries may be `pinned` or `paper-only` only when their status
+is explicit.
+
+## Validator design
+
+Docker is unavailable on the test machine. The approved fallback is:
+
+- pinned CPython 3.9 standard-library execution;
+- macOS `sandbox-exec` with reads limited to the candidate, public input, and
+  pinned interpreter/runtime files, no network, a scrubbed environment, and
+  read-only input;
+- parent-enforced 30-second wall-clock timeout;
+- validator-private scorer and holdout files outside attempt worktrees; and
+- a manifest that records the fallback reason, interpreter identity, sandbox
+  policy hash, source-data hashes, holdout query budget, and self-test results.
+
+The CLI implements the published contract:
+
+```text
+validate <candidate-dir> [--precheck] [--instances dev|holdout]
+         [--out report.json]
+```
+
+The validator gate requires:
+
+- a baseline end-to-end development score;
+- rejection of `cheater`, `wrong-answer`, `timeout`, and `env-escape`;
+- rejection of a topic-specific public-row lookup-table control;
+- an informative `errors[]` entry for every rejection; and
+- no more than five-percent timeout overshoot.
+
+If the platform cannot make validator-private files inaccessible to the
+candidate process, the gate fails. A prompt-only “do not read” instruction is
+not an acceptable fallback.
+
+## Research-loop design
+
+`research/STATE.md` is configured with:
+
+- `batch_size: 3`;
+- `time_limit_seconds: 30`;
+- `authorized_rounds: 1`;
+- one holdout aggregate query available for the cycle; and
+- attempts numbered from `001`.
+
+Before creating attempt worktrees, all public pipeline artifacts required by a
+candidate are committed as an immutable baseline. `.worktrees/` is ignored.
+Every attempt branch records its exact base commit.
+
+The batch contains:
+
+- at least one distinct draft;
+- at least one single-change improvement over the best known baseline; and
+- at most one debug attempt.
+
+Each attempt writes `LOG.md` before implementation, runs `--precheck`, receives
+exactly one development score, and records the complete JSON result. Crashes
+and timeouts consume an attempt. The cycle ends with an honest yield report in
+`docs/discussion/`, including the denominator, best score, causal interpretation,
+dead approaches, holdout use, and distance to the goal.
+
+## Ten-topic undergraduate reserve
+
+A separate deliverable, `examples/neutral-atom-autoresearch-topics.md`, contains
+exactly ten topics. Each topic includes:
+
+- a concrete research question;
+- at least one current primary reference showing an open method or modeling
+  gap;
+- Checkable, Cheap, Headroom, and Publishable scores with justifications;
+- one primary metric and at least one guard metric;
+- per-attempt cost;
+- required dataset or simulator;
+- principal gaming risk and its negative control; and
+- recommended undergraduate prerequisites.
+
+All ten topics must score at least 3 on Checkable and Cheap. Topics that only
+repackage data collection, require private hardware, or need multi-day
+simulation per attempt are excluded.
+
+## Expected skill improvements
+
+Only friction reproduced by the smoke test is changed. The initial audit will
+specifically test these suspected protocol gaps:
+
+1. whether a new-project dispatcher initializes portable state without
+   assuming a platform-specific `AskUserQuestion` tool;
+2. whether the validator's “scorer unreachable” rule is compatible with its
+   prescribed repository layout;
+3. whether attempt worktrees receive a committed public baseline and an
+   explicit parent ref;
+4. whether `.worktrees/` is ignored before creation;
+5. whether pre-authorized stage choices can be consumed without repeated
+   blocking prompts; and
+6. whether structural tests verify the operational invariants rather than
+   only marker phrases.
+
+Each accepted fix gets a failing regression test first. Unreproduced concerns
+remain documented findings, not speculative edits.
+
+## Error handling
+
+- Source download failure: retry the three exact CaltechDATA file URLs, verify
+  MD5, then stop rather than substitute synthetic data silently.
+- NPY incompatibility: reject unsupported dtype/shape with a specific error;
+  do not coerce silently.
+- Missing Docker: use the recorded `sandbox-exec` fallback above.
+- Sandbox self-test failure: validator gate remains closed.
+- Dirty or uncommitted attempt baseline: run stage refuses to create a
+  worktree.
+- Existing unrelated test failures: report separately and require the focused
+  autoresearch regression suite to remain green.
+- GitHub upstream lacks push permission: push the PR branch to a user-owned
+  fork and open a PR against `QuantumBFS/sci-brain:main`.
+
+## Verification
+
+Completion requires all of the following evidence:
+
+1. the dispatcher routes the isolated project through `topics`, `db`,
+   `validator`, `run`, and `done`;
+2. all survey and validator gate artifacts exist and agree with `STATE.md`;
+3. every negative control is rejected as specified;
+4. three attempt worktrees and three complete `LOG.md` files exist;
+5. one reflection report records the three-attempt yield;
+6. the ten-topic reserve has exactly ten fully metricized entries backed by
+   primary references;
+7. focused autoresearch tests pass;
+8. the repository-wide test delta introduces no new failure beyond the seven
+   failures present at baseline (111 passed, 7 failed);
+9. the PR diff contains only reproduced skill fixes, their tests, the example,
+   and the worktree-ignore rule; and
+10. the pushed branch and pull request are inspectable on GitHub.

--- a/docs/specs/2026-07-20-autoresearch-neutral-atom-smoke-test-plan.md
+++ b/docs/specs/2026-07-20-autoresearch-neutral-atom-smoke-test-plan.md
@@ -1,0 +1,852 @@
+# Neutral-Atom Autoresearch Suite Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:executing-plans` to implement this plan task-by-task. Do not
+> dispatch subagents: this thread's collaboration policy requires inline
+> execution. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run the complete sci-brain autoresearch pipeline on official
+neutral-atom Rabi data, improve only the skill defects reproduced by that run,
+produce ten validator-ready undergraduate topics, and submit the verified
+changes as a pull request.
+
+**Architecture:** Skill changes are developed in the isolated
+`codex/test-autoresearch-neutral-atom` worktree with grep-based regression
+tests. The scientific smoke test runs in a separate clean clone of
+`AtomicQCPlatformData`; its validator executes candidates through a
+macOS-sandboxed, standard-library-only process, while private labels and scorer
+code remain outside attempt worktrees. Reproducible public results and the
+ten-topic reserve are copied into sci-brain as an example; private benchmark
+material and attempt worktrees are not committed to the PR.
+
+**Tech Stack:** Markdown skill protocols, Python 3.9 standard library,
+`sandbox-exec`, Git worktrees, pytest 8.4.1 in a temporary dependency directory,
+CaltechDATA NPY files, GitHub CLI/app.
+
+## Global Constraints
+
+- Preserve the full four-stage pipeline: topics → db → validator → run.
+- Use the official CaltechDATA record `10.22002/4m9sp-yzr58`; do not silently
+  replace missing public data with synthetic data.
+- Describe Fig. 4a as processed populations, not raw shot-level bitstrings.
+- Keep estimable quantities, scenario bounds, and unidentifiable parameters
+  distinct.
+- Use `batch_size: 3`, `time_limit_seconds: 30`, and
+  `authorized_rounds: 1` for the smoke run.
+- Every skill edit must be preceded by a focused failing regression test.
+- Do not modify or clean the user's existing uncommitted
+  `AtomicQCPlatformData` files.
+- A validator sandbox failure keeps the validator gate closed.
+- Do not add reviewers to the pull request unless the user asks.
+- Treat the seven repository-wide baseline failures as pre-existing; introduce
+  no additional full-suite failures.
+
+---
+
+### Task 1: Make installation and stage approvals portable
+
+**Files:**
+- Modify: `.codex/INSTALL.md`
+- Modify: `skills/autoresearch/SKILL.md`
+- Modify: `skills/autoresearch/references/state-schema.md`
+- Create: `skills/autoresearch/references/approval-contract.md`
+- Modify: `skills/autoresearch-topics/SKILL.md`
+- Modify: `skills/autoresearch-db/SKILL.md`
+- Modify: `skills/autoresearch-validator/SKILL.md`
+- Test: `tests/test_autoresearch_skills.py`
+
+**Interfaces:**
+- Consumes: an exact user decision from the current conversation or
+  `<project>/research/APPROVALS.md`.
+- Produces: a portable approval lookup protocol and a valid Codex installation
+  procedure that links every real skill directory.
+
+- [ ] **Step 1: Write failing portability tests**
+
+Append these tests:
+
+```python
+def test_codex_install_links_real_skill_directories():
+    text = (ROOT / ".codex" / "INSTALL.md").read_text()
+    assert "skills/sci-brain" not in text
+    assert 'for skill in "$HOME/.codex/sci-brain/skills"/*' in text
+    assert 'ln -sfn "$skill"' in text
+
+
+def test_approval_contract_is_portable_and_auditable():
+    contract = _ref("autoresearch", "approval-contract.md")
+    assert "research/APPROVALS.md" in contract
+    assert "current conversation" in contract
+    assert "platform" in contract.lower()
+    assert "pre-authorized" in contract
+    assert "never infer" in contract.lower()
+
+
+def test_interactive_stages_use_shared_approval_contract():
+    for skill in [
+        "autoresearch",
+        "autoresearch-topics",
+        "autoresearch-db",
+        "autoresearch-validator",
+    ]:
+        text = _read(skill)
+        assert "approval-contract.md" in text
+    state = _ref("autoresearch", "state-schema.md")
+    assert "approval_log:" in state
+```
+
+- [ ] **Step 2: Run the tests and verify failure**
+
+Run:
+
+```bash
+PYTHONPATH=/private/tmp/sci-brain-test-deps \
+  /Users/mingrui/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 \
+  -m pytest -q tests/test_autoresearch_skills.py \
+  -k 'codex_install or approval_contract or interactive_stages'
+```
+
+Expected: failures for the nonexistent install target, missing approval
+contract, and missing `approval_log`.
+
+In the same test edit, replace the existing stage-specific assertions that
+require the literal `AskUserQuestion` tool with assertions for
+`approval-contract.md`, explicit user selection, and the unchanged stage
+advance. This prevents a Claude-specific UI name from remaining a false
+portability requirement.
+
+- [ ] **Step 3: Add the shared approval contract**
+
+Create `approval-contract.md` with this complete protocol:
+
+```markdown
+# Stage approval contract
+
+Every stage decision is explicit and auditable.
+
+1. Check the current conversation for an exact decision that names the
+   selected item or approved configuration.
+2. Check `research/APPROVALS.md` when `approval_log:` in `STATE.md` points to
+   it. A valid entry records UTC date, stage, decision, scope, and provenance
+   (`conversation` or `approval-log`).
+3. If the exact decision is already pre-authorized, copy it into the approval
+   log and continue without asking again.
+4. Otherwise use the platform's available user-input mechanism. `AskUserQuestion`
+   is one implementation, not a required tool; plain chat or another native
+   picker is valid.
+5. Never infer approval from silence, a broad project goal, or approval of a
+   different metric or stage.
+
+Changing a recorded decision requires a new append-only entry. Protocol
+deviations still belong under `overrides:` in `STATE.md`; an approval is not an
+override.
+```
+
+- [ ] **Step 4: Update the dispatcher, stages, state, and installer**
+
+Add `- approval_log: research/APPROVALS.md` to the state template. Link the
+contract from every interactive stage and replace tool-specific
+`AskUserQuestion` requirements with:
+
+```markdown
+Resolve the decision via
+`skills/autoresearch/references/approval-contract.md`. Consume an exact
+pre-authorized decision without prompting; otherwise use the platform's
+available user-input mechanism.
+```
+
+Replace the broken Codex symlink with:
+
+```bash
+mkdir -p "$HOME/.agents/skills"
+for skill in "$HOME/.codex/sci-brain/skills"/*; do
+  [ -f "$skill/SKILL.md" ] || continue
+  ln -sfn "$skill" "$HOME/.agents/skills/$(basename "$skill")"
+done
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run the Step 2 command. Expected: all selected tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .codex/INSTALL.md tests/test_autoresearch_skills.py \
+  skills/autoresearch skills/autoresearch-topics/SKILL.md \
+  skills/autoresearch-db/SKILL.md skills/autoresearch-validator/SKILL.md
+git commit -m "fix: make autoresearch approvals portable"
+```
+
+---
+
+### Task 2: Make validator privacy enforceable
+
+**Files:**
+- Modify: `skills/autoresearch-validator/SKILL.md`
+- Modify: `skills/autoresearch-validator/references/validator-contract.md`
+- Modify: `skills/autoresearch-validator/references/negative-controls.md`
+- Test: `tests/test_autoresearch_skills.py`
+
+**Interfaces:**
+- Consumes: candidate directory, public development inputs, private scorer and
+  holdout roots.
+- Produces: a validator gate that fails closed unless candidate code is unable
+  to read validator-private and holdout files.
+
+- [ ] **Step 1: Write failing privacy tests**
+
+Append:
+
+```python
+def test_validator_private_layout_is_outside_attempts():
+    text = _read("autoresearch-validator")
+    for marker in [
+        "research/validator/private/",
+        "research/benchmark/private/",
+        "outside the attempt worktree",
+        "fail closed",
+        "policy hash",
+    ]:
+        assert marker in text
+
+
+def test_env_escape_control_probes_both_private_roots():
+    text = _ref("autoresearch-validator", "negative-controls.md")
+    assert "validator/private" in text
+    assert "benchmark/private" in text
+    assert "network" in text
+
+
+def test_contract_records_private_hashes_without_labels():
+    text = _ref("autoresearch-validator", "validator-contract.md")
+    assert "scorer_hash" in text
+    assert "holdout_hash" in text
+    assert "sandbox_policy_hash" in text
+    assert "never labels" in text.lower()
+```
+
+- [ ] **Step 2: Verify the tests fail**
+
+Run:
+
+```bash
+PYTHONPATH=/private/tmp/sci-brain-test-deps \
+  /Users/mingrui/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 \
+  -m pytest -q tests/test_autoresearch_skills.py \
+  -k 'validator_private or env_escape_control or private_hashes'
+```
+
+Expected: all three tests fail on missing operational requirements.
+
+- [ ] **Step 3: Correct the validator layout and gate**
+
+Specify:
+
+```text
+research/validator/            tracked public contract, launcher, manifest
+research/validator/private/    ignored scorer core and private expected values
+research/benchmark/dev/        tracked public development inputs
+research/benchmark/private/    ignored holdout inputs/labels
+```
+
+Require both private directories in `.gitignore`; require the validator process
+to live outside attempt worktrees; require candidate execution in a sandbox
+that can read only candidate files, public inputs, and pinned runtime files.
+Record `scorer_hash`, `holdout_hash`, and `sandbox_policy_hash` in the manifest.
+Use the exact phrase “fail closed” when any forbidden read or network probe
+succeeds.
+
+- [ ] **Step 4: Strengthen the environment-escape control**
+
+Define an `env-escape` candidate that separately attempts:
+
+```python
+open("../research/validator/private/scorer.py", "rb")
+open("../research/benchmark/private/labels.json", "rb")
+socket.create_connection(("example.com", 80), timeout=1)
+```
+
+The control passes only if all attempts are blocked and named in `errors[]`.
+
+- [ ] **Step 5: Run focused and full autoresearch tests**
+
+Run the Step 2 command, then:
+
+```bash
+PYTHONPATH=/private/tmp/sci-brain-test-deps \
+  /Users/mingrui/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 \
+  -m pytest -q tests/test_autoresearch_skills.py
+```
+
+Expected: privacy tests pass; the entire focused file passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_autoresearch_skills.py skills/autoresearch-validator
+git commit -m "fix: seal autoresearch validator private state"
+```
+
+---
+
+### Task 3: Make attempt worktrees reproducible
+
+**Files:**
+- Modify: `skills/autoresearch/references/state-schema.md`
+- Modify: `skills/autoresearch-run/SKILL.md`
+- Modify: `skills/autoresearch-run/references/attempt-protocol.md`
+- Modify: `skills/autoresearch-run/references/reflection-template.md`
+- Test: `tests/test_autoresearch_skills.py`
+
+**Interfaces:**
+- Consumes: a clean committed `baseline_commit` and an optional ancestor attempt
+  commit.
+- Produces: explicit attempt branches/worktrees whose parent commit is recorded
+  before implementation.
+
+- [ ] **Step 1: Write failing worktree tests**
+
+Append:
+
+```python
+def test_state_records_committed_attempt_baseline():
+    text = _ref("autoresearch", "state-schema.md")
+    assert "baseline_commit:" in text
+
+
+def test_run_preflights_worktree_and_clean_baseline():
+    text = _read("autoresearch-run")
+    for marker in [
+        "git check-ignore -q .worktrees",
+        "git status --porcelain",
+        "git merge-base --is-ancestor",
+        "baseline_commit",
+        "public pipeline artifacts",
+        "refuse",
+    ]:
+        assert marker in text
+
+
+def test_attempt_creation_names_branch_and_parent_ref():
+    text = _ref("autoresearch-run", "attempt-protocol.md")
+    assert "git worktree add -b autoresearch/attempt-NNN" in text
+    assert "<parent-ref>" in text
+    assert "**base commit**" in text
+    assert "**result commit**" in text
+```
+
+- [ ] **Step 2: Verify the tests fail**
+
+Run:
+
+```bash
+PYTHONPATH=/private/tmp/sci-brain-test-deps \
+  /Users/mingrui/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 \
+  -m pytest -q tests/test_autoresearch_skills.py \
+  -k 'committed_attempt_baseline or preflights_worktree or names_branch'
+```
+
+Expected: failures for missing baseline and explicit worktree lineage.
+
+- [ ] **Step 3: Add baseline preflight**
+
+Add `baseline_commit: (unset)` to state. Before a cycle, require:
+
+```bash
+git check-ignore -q .worktrees
+git status --porcelain --untracked-files=all
+git rev-parse HEAD
+```
+
+The run stage refuses if `.worktrees/` is not ignored, if any public pipeline
+artifact is uncommitted, or if `baseline_commit` is not an ancestor of the
+clean orchestration HEAD. Ignored private validator and holdout files are
+allowed. The baseline SHA names the immutable candidate-visible tree; the
+later commit that records that SHA in `STATE.md` is orchestration metadata and
+does not redefine the baseline.
+
+- [ ] **Step 4: Make attempt creation explicit**
+
+Define parent resolution:
+
+```text
+draft   -> baseline_commit
+improve -> result commit of the named successful parent attempt
+debug   -> result commit of the named failed parent attempt
+```
+
+Create with:
+
+```bash
+git worktree add -b autoresearch/attempt-NNN \
+  .worktrees/attempt-NNN <parent-ref>
+```
+
+Record base commit before implementation and result commit after the attempt.
+If the candidate crashes before a result commit, record `result commit:
+(none—crashed)` and never reuse the number.
+
+- [ ] **Step 5: Run tests**
+
+Run the Step 2 command followed by the entire focused test file. Expected: all
+pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_autoresearch_skills.py \
+  skills/autoresearch/references/state-schema.md \
+  skills/autoresearch-run
+git commit -m "fix: pin autoresearch attempt worktree lineage"
+```
+
+---
+
+### Task 4: Build the isolated neutral-atom smoke project
+
+**Files:**
+- Create outside PR repo:
+  `/private/tmp/atomicqc-autoresearch-smoke/`
+- Create runtime artifacts:
+  `topics.md`, `research/STATE.md`, `research/APPROVALS.md`,
+  `.knowledge/`, `research/INSIGHTS.md`, `research/CATALOG.md`,
+  `research/database/`, `research/benchmark/`, `research/validator/`
+- Test:
+  `/private/tmp/atomicqc-autoresearch-smoke/tests/test_data_and_validator.py`
+
+**Interfaces:**
+- Consumes: three CaltechDATA NPY URLs and their published MD5 values.
+- Produces: immutable public data, development/private splits, a baseline
+  candidate, and a validator ready for strictness self-test.
+
+- [ ] **Step 1: Clone the local dataset project without user dirt**
+
+Run:
+
+```bash
+git clone --no-hardlinks /Users/mingrui/Projects/AtomicQCPlatformData \
+  /private/tmp/atomicqc-autoresearch-smoke
+git -C /private/tmp/atomicqc-autoresearch-smoke switch -c \
+  autoresearch/rabi-envelope-smoke
+```
+
+Expected: a clean independent clone; no files are written into the user's
+existing checkout.
+
+- [ ] **Step 2: Initialize dispatcher state and pre-authorizations**
+
+Create `research/STATE.md` from the revised template with:
+
+```text
+stage: topics
+topic: rabi-envelope-recovery
+batch_size: 3
+time_limit_seconds: 30
+authorized_rounds: 1
+next_attempt: 1
+next_cycle: 1
+baseline_commit: (unset)
+approval_log: research/APPROVALS.md
+```
+
+Create append-only approvals for the topic, approved metrics, five Selected
+insight areas, validator goal, fallback environment, and one authorized round.
+
+- [ ] **Step 3: Download and verify the official arrays**
+
+Download:
+
+```text
+https://data.caltech.edu/records/4m9sp-yzr58/files/fig4a_rabi_duration.npy?download=1
+https://data.caltech.edu/records/4m9sp-yzr58/files/fig4a_rabi_pop_1.npy?download=1
+https://data.caltech.edu/records/4m9sp-yzr58/files/fig4a_rabi_pop_1_std.npy?download=1
+```
+
+Verify MD5:
+
+```text
+93c6bd2d084f5c80075c75c8976fe765  fig4a_rabi_duration.npy
+a0432de3d76551610e2a795803eb82dd  fig4a_rabi_pop_1.npy
+7b95de05b41d1e05fdba72dc90b20334  fig4a_rabi_pop_1_std.npy
+```
+
+Write provenance to `research/database/README.md` and immutable records to
+`research/database/source-manifest.json`.
+
+- [ ] **Step 4: Write the NPY/data tests first**
+
+Create standard-library `unittest` cases that assert:
+
+```python
+self.assertEqual(len(duration), len(population))
+self.assertEqual(len(population), len(sigma))
+self.assertGreater(len(duration), 20)
+self.assertTrue(all(t >= 0 for t in duration))
+self.assertTrue(all(0 <= p <= 1 for p in population))
+self.assertTrue(all(s > 0 for s in sigma))
+```
+
+Also test that an MD5 mismatch and a non-1D/non-float NPY file raise specific
+`ValueError` messages.
+
+- [ ] **Step 5: Implement the smallest standard-library NPY reader**
+
+Implement `load_1d_float(path: Path) -> list[float]` using:
+
+```python
+magic = stream.read(6)
+version = tuple(stream.read(2))
+header_len = struct.unpack("<H" if version == (1, 0) else "<I",
+                           stream.read(2 if version == (1, 0) else 4))[0]
+header = ast.literal_eval(stream.read(header_len).decode("latin1"))
+```
+
+Accept only little-endian `f8` or `f4`, `fortran_order == False`, and one
+dimension. Reject all other formats explicitly.
+
+- [ ] **Step 6: Run data tests**
+
+Run:
+
+```bash
+python3 -m unittest discover -s tests -p 'test_data_and_validator.py' -v
+```
+
+Expected: all data tests pass.
+
+- [ ] **Step 7: Execute the topics and DB stages**
+
+Write the approved smoke topic and metric block to `topics.md`. Use
+`download-ref` to populate `.knowledge/` from authoritative arXiv/DOI
+references covering all five approved insight areas. Write
+`research/INSIGHTS.md`, select all five pre-authorized areas, reproduce the
+undamped baseline, and write `research/CATALOG.md`.
+
+Advance only after the survey gate checklist passes on disk.
+
+- [ ] **Step 8: Write validator controls and tests before the scorer**
+
+The tests invoke the public CLI against:
+
+```text
+baseline
+controls/cheater
+controls/wrong-answer
+controls/timeout
+controls/env-escape
+controls/public-row-lookup
+```
+
+Assert exit codes, JSON status, named `errors[]`, timeout overshoot below five
+percent, and blocked private/network access.
+
+- [ ] **Step 9: Implement and self-test the validator**
+
+Use a public launcher and ignored private scorer. Candidate output contract:
+
+```json
+{
+  "predictions": [{"instance": "id", "population": 0.5}],
+  "omega_rad_per_s": 1.0,
+  "model": "undamped|exponential|gaussian|other"
+}
+```
+
+The scorer computes uncertainty-normalized RMSE, enforces guards, and emits the
+validator-contract JSON. Run all controls, hash the private scorer, holdout,
+sandbox policy, and interpreter, then record results in `manifest.json`.
+
+- [ ] **Step 10: Commit the public baseline**
+
+Ensure private paths and `.worktrees/` are ignored. Commit all public topic,
+evidence, database, development, validator-contract, and baseline-candidate
+artifacts while `baseline_commit` is unset; capture that commit SHA. Update
+`STATE.md` with the captured SHA and create a second orchestration commit.
+Verify the baseline is an ancestor of the clean HEAD and that later
+orchestration-only changes do not alter candidate-visible files.
+
+---
+
+### Task 5: Run one three-attempt autoresearch cycle
+
+**Files:**
+- Runtime:
+  `/private/tmp/atomicqc-autoresearch-smoke/.worktrees/attempt-001..003/`
+- Runtime:
+  `/private/tmp/atomicqc-autoresearch-smoke/docs/discussion/<timestamp>-cycle-01.md`
+
+**Interfaces:**
+- Consumes: passed survey/validator gates and committed baseline.
+- Produces: three validator-scored attempts, lineage-complete logs, and one
+  reflection report.
+
+- [ ] **Step 1: Verify entry gate and worktree preflight**
+
+Check every artifact named by `autoresearch-run`, `.worktrees/` ignore state,
+clean public baseline, and state/HEAD SHA agreement. Expected: gate passes.
+
+- [ ] **Step 2: Plan a surplus and choose three non-duplicate hypotheses**
+
+Generate at least six hypotheses from Selected insights. Rank by information
+gain, cost, and distinctness. Promote one draft, one atomic improvement, and
+one additional draft or debug according to the run protocol. Record rejected
+near-duplicates before implementation.
+
+- [ ] **Step 3: Execute attempts 001–003**
+
+For each attempt:
+
+1. increment state numbering immediately;
+2. create the explicitly named branch/worktree from the resolved parent;
+3. write `LOG.md` before candidate code;
+4. run unlimited `--precheck`;
+5. run exactly one development score;
+6. append JSON result and learning to `LOG.md`;
+7. commit the candidate and log; and
+8. leave the worktree intact.
+
+- [ ] **Step 4: Spend the authorized aggregate holdout query**
+
+Run only the cycle's best development candidate on holdout. Record aggregate
+pass/fail and budget decrement; do not expose labels.
+
+- [ ] **Step 5: Write reflection and update state**
+
+Write all required reflection sections, including “K of 3 attempts improved”,
+best score versus baseline, causal ranking, dead approaches, literature
+check, holdout decision, and distance to goal. Set `authorized_rounds: 0`;
+set `stage: done` only if the predefined dev and holdout bars both pass.
+
+- [ ] **Step 6: Verify the run audit**
+
+Assert exactly three unique attempt directories, three complete `LOG.md`
+files, three validator reports, one reflection, and consistent state counters.
+
+---
+
+### Task 6: Build the ten-topic undergraduate reserve
+
+**Files:**
+- Create: `examples/neutral-atom-autoresearch-topics.md`
+- Test: `tests/test_neutral_atom_autoresearch_example.py`
+
+**Interfaces:**
+- Consumes: current primary literature and the `autoresearch-topics` scoring
+  protocol.
+- Produces: exactly ten independently runnable, fully metricized topics.
+
+- [ ] **Step 1: Write the failing reserve-structure test**
+
+Parse headings `## Topic 01` through `## Topic 10` and require, within each
+section:
+
+```text
+### Research question
+### Evidence that the gap is open
+### Suitability
+### Metrics
+### Cost and resources
+### Gaming risk and negative control
+### Undergraduate prerequisites
+```
+
+Require `**Checkable:**`, `**Cheap:**`, `**Headroom:**`,
+`**Publishable:**`, `**Primary metric**`, and `**Guard metric**`. Parse scores
+and assert Checkable and Cheap are each at least 3.
+
+- [ ] **Step 2: Run the test and verify failure**
+
+Run:
+
+```bash
+PYTHONPATH=/private/tmp/sci-brain-test-deps \
+  /Users/mingrui/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 \
+  -m pytest -q tests/test_neutral_atom_autoresearch_example.py
+```
+
+Expected: failure because the reserve does not exist.
+
+- [ ] **Step 3: Search and deduplicate current primary references**
+
+For each candidate topic, search arXiv/CrossRef/publisher sources first,
+deduplicate by normalized DOI or title/first-author, and retain at least one
+primary reference that explicitly supplies data, a benchmark, or an open
+limitation. Do not use a review alone as evidence that the gap is open.
+
+- [ ] **Step 4: Write all ten fully metricized topics**
+
+Cover complementary neutral-atom modeling lanes:
+
+1. Rabi envelope recovery;
+2. Ramsey dephasing-family discrimination;
+3. spatial Rabi-inhomogeneity compression;
+4. coherent transport trajectory surrogate modeling;
+5. RB decay with leakage/loss separation;
+6. CZ coherent-angle scenario bounds;
+7. gate-speed error-budget response fitting;
+8. Aquila bitstring observation-model checks;
+9. correlated phase-noise detection;
+10. active pulse sampling for identifiability.
+
+If literature evidence makes one lane uncheckable or too costly, replace it
+with another lane rather than lowering the score threshold.
+
+- [ ] **Step 5: Run the reserve test**
+
+Run the Step 2 command. Expected: pass with exactly ten topics.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/neutral-atom-autoresearch-topics.md \
+  tests/test_neutral_atom_autoresearch_example.py
+git commit -m "docs: add neutral-atom autoresearch topic reserve"
+```
+
+---
+
+### Task 7: Add the reproducible smoke-test report
+
+**Files:**
+- Create: `examples/neutral-atom-autoresearch-smoke/README.md`
+- Create: `examples/neutral-atom-autoresearch-smoke/run-summary.md`
+- Create: `examples/neutral-atom-autoresearch-smoke/source-manifest.json`
+- Modify: `tests/test_neutral_atom_autoresearch_example.py`
+
+**Interfaces:**
+- Consumes: authoritative runtime state, manifest, attempts, and reflection.
+- Produces: a source-grounded public audit without private labels.
+
+- [ ] **Step 1: Extend the example test first**
+
+Require the summary to name:
+
+```text
+topics
+survey gate
+validator gate
+attempt-001
+attempt-002
+attempt-003
+baseline score
+best development score
+holdout
+reflection
+```
+
+Validate source-manifest DOI, three filenames, MD5 values, and that no path
+contains `benchmark/private`, `validator/private`, or `.worktrees`.
+
+- [ ] **Step 2: Verify the extended test fails**
+
+Run the example test. Expected: missing report artifacts.
+
+- [ ] **Step 3: Copy only public evidence**
+
+Write the README with reproduction instructions and the run summary with exact
+scores, gate results, environment downgrade, negative-control results, attempt
+yield, and skill friction/fixes. Copy only public source metadata, never the
+private benchmark, private scorer, or worktree contents.
+
+- [ ] **Step 4: Run example tests**
+
+Run the example test. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/neutral-atom-autoresearch-smoke \
+  tests/test_neutral_atom_autoresearch_example.py
+git commit -m "test: document neutral-atom autoresearch smoke run"
+```
+
+---
+
+### Task 8: Complete regression and scope verification
+
+**Files:**
+- Inspect all changed files.
+
+**Interfaces:**
+- Consumes: complete branch.
+- Produces: evidence that focused tests pass and no new repository-wide failure
+  was introduced.
+
+- [ ] **Step 1: Run focused tests**
+
+```bash
+PYTHONPATH=/private/tmp/sci-brain-test-deps \
+  /Users/mingrui/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 \
+  -m pytest -q tests/test_autoresearch_skills.py \
+  tests/test_neutral_atom_autoresearch_example.py
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run the full suite**
+
+```bash
+PYTHONPATH=/private/tmp/sci-brain-test-deps \
+  /Users/mingrui/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 \
+  -m pytest -q
+```
+
+Expected: exactly the same seven pre-existing failures and no new failures.
+
+- [ ] **Step 3: Audit diff and protocol coverage**
+
+Run:
+
+```bash
+git diff --check origin/main...HEAD
+git diff --stat origin/main...HEAD
+git status --short --branch
+```
+
+Review every spec requirement against the branch and runtime artifacts. Remove
+speculative changes not reproduced by the smoke test.
+
+- [ ] **Step 4: Perform a read-only code/skill review**
+
+Use the requesting-code-review workflow locally. Resolve every correctness or
+scope issue before publishing.
+
+---
+
+### Task 9: Publish the pull request
+
+**Files:**
+- No new source files unless publication checks reveal a defect.
+
+**Interfaces:**
+- Consumes: clean reviewed branch.
+- Produces: pushed `codex/test-autoresearch-neutral-atom` branch and PR against
+  `QuantumBFS/sci-brain:main`.
+
+- [ ] **Step 1: Confirm GitHub identity and permission**
+
+Run `gh auth status`. Upstream currently grants pull but not push permission,
+so create or reuse the authenticated user's fork.
+
+- [ ] **Step 2: Push the exact reviewed branch**
+
+Push `codex/test-autoresearch-neutral-atom` to the user-owned fork. Re-run
+`git rev-parse HEAD` and confirm the remote branch SHA matches.
+
+- [ ] **Step 3: Open a ready PR with no requested reviewers**
+
+The PR body includes:
+
+- problem reproduced by the real smoke run;
+- concise protocol fixes;
+- actual three-attempt results;
+- ten-topic reserve;
+- focused and full-suite test evidence;
+- seven pre-existing failures clearly separated; and
+- source-data DOI/license.
+
+- [ ] **Step 4: Verify PR metadata and checks**
+
+Read back PR base/head, diff, reviewer requests, and initial checks. Reviewer
+requests must be empty. Report PR, CI, reviewer, and merge state separately.

--- a/examples/neutral-atom-autoresearch-smoke/README.md
+++ b/examples/neutral-atom-autoresearch-smoke/README.md
@@ -1,0 +1,32 @@
+# Neutral-atom Rabi autoresearch smoke test
+
+This example records a complete `autoresearch` run:
+
+1. `autoresearch-topics` selected robust Rabi carrier/envelope recovery;
+2. `autoresearch-db` built a five-paper evidence base and passed the survey
+   gate;
+3. `autoresearch-validator` built a sealed scorer, passed the validator gate
+   against four negative controls, and froze an undamped baseline score;
+4. `autoresearch-run` executed attempt-001 through attempt-003 in separate
+   branches, reflected on the batch, and spent one aggregate holdout query.
+
+The source is the open Fig. 4a processed population scan from CaltechDATA DOI
+[`10.22002/4m9sp-yzr58`](https://doi.org/10.22002/4m9sp-yzr58). These are
+processed populations and uncertainties, not raw bitstrings.
+
+## Reproduction outline
+
+- Download the three files in `source-manifest.json` and verify their MD5
+  hashes.
+- Fit the frozen undamped weighted sinusoid on the even-index development
+  rows and score odd-index predictions with an uncertainty floor of `1e-4`.
+- Compare a Gaussian frequency-spread envelope and an exponential envelope
+  under the same frequency bounds and output guards.
+- Keep the scorer and holdout outside candidate worktrees; run the cheater,
+  wrong-answer, timeout, and environment-escape controls before scoring.
+- Use development scores to select one winner, then consume at most one
+  aggregate holdout query and write a cycle reflection.
+
+The original run used CPython 3.12.13 with macOS `sandbox-exec` because Docker
+was unavailable. The fallback and its policy hash were recorded rather than
+silently substituted.

--- a/examples/neutral-atom-autoresearch-smoke/run-summary.md
+++ b/examples/neutral-atom-autoresearch-smoke/run-summary.md
@@ -1,0 +1,54 @@
+# Run summary
+
+## Gates
+
+- topics: selected “Robust recovery of microwave Rabi frequency and envelope
+  dynamics from a sparse processed population scan.”
+- survey gate: passed after five selected, source-grounded insights and three
+  reproduced envelope references.
+- validator gate: passed after baseline end-to-end scoring and 4/4 strictness
+  controls rejected.
+- environment: fallback, CPython 3.12.13 plus a hashed macOS Seatbelt policy.
+
+## Attempts
+
+| Attempt | Kind | Change | Development result |
+|---|---|---|---:|
+| attempt-001 | draft | Gaussian frequency-spread envelope | `4.372371385616318`, scored |
+| attempt-002 | draft | exponential envelope | rejected: one population outside `[0,1]` |
+| attempt-003 | improve 001 | uncertainty floor `1e-4` → `1e-3` | `4.474516584277779`, scored but worse |
+
+The baseline score was `40.86068140668919`; the best development score was
+`4.372371385616318` from attempt-001.
+
+## Sealed adjudication and reflection
+
+The single holdout query was spent on attempt-001. Its aggregate normalized
+RMSE was `1.4843925406501801`, versus the frozen holdout baseline
+`37.3765738659451`; the non-inferiority bar passed. Labels were never copied
+into the reflection or this report.
+
+Cycle reflection:
+
+- the Gaussian envelope was the only primary-metric improvement;
+- the unconstrained exponential form was blacklisted because it violated the
+  population guard;
+- the `1e-3` weighting floor was retained as negative evidence;
+- the result supports an effective ensemble frequency-spread model, not a
+  unique microscopic coherent-error identification.
+
+## Skill friction found during the run
+
+Four reproducible protocol problems were repaired with regression tests:
+
+1. the Codex installer linked a nonexistent aggregate skill directory;
+2. approval handling named a platform-specific UI tool and could not consume
+   exact pre-authorization portably;
+3. validator-private state and attempt lineage were described but not
+   enforceably pinned;
+4. an exact pre-approved reference batch still prompted once per cite key.
+
+The real smoke validator also demonstrated why environment failure must remain
+fail-closed: `sandbox-exec` cannot be nested inside the Codex outer sandbox,
+so the same tests were rerun with explicit permission where the inner policy
+could take effect.

--- a/examples/neutral-atom-autoresearch-smoke/source-manifest.json
+++ b/examples/neutral-atom-autoresearch-smoke/source-manifest.json
@@ -1,0 +1,25 @@
+{
+  "article_doi": "10.1038/s41586-025-09641-4",
+  "dataset_doi": "10.22002/4m9sp-yzr58",
+  "files": [
+    {
+      "filename": "fig4a_rabi_duration.npy",
+      "md5": "93c6bd2d084f5c80075c75c8976fe765",
+      "role": "drive duration in seconds",
+      "url": "https://data.caltech.edu/records/4m9sp-yzr58/files/fig4a_rabi_duration.npy?download=1"
+    },
+    {
+      "filename": "fig4a_rabi_pop_1.npy",
+      "md5": "a0432de3d76551610e2a795803eb82dd",
+      "role": "processed state-|1> population",
+      "url": "https://data.caltech.edu/records/4m9sp-yzr58/files/fig4a_rabi_pop_1.npy?download=1"
+    },
+    {
+      "filename": "fig4a_rabi_pop_1_std.npy",
+      "md5": "7b95de05b41d1e05fdba72dc90b20334",
+      "role": "reported one-sigma population uncertainty",
+      "url": "https://data.caltech.edu/records/4m9sp-yzr58/files/fig4a_rabi_pop_1_std.npy?download=1"
+    }
+  ],
+  "source_type": "official processed source data"
+}

--- a/examples/neutral-atom-autoresearch-topics.md
+++ b/examples/neutral-atom-autoresearch-topics.md
@@ -1,0 +1,409 @@
+# Neutral-atom autoresearch topic reserve
+
+These ten scoped projects were screened with the `autoresearch-topics`
+rubric. “Publishable” means the project can produce a reusable benchmark or
+carefully bounded method result; it does not promise a new physics discovery.
+Primary data sources are the open CaltechDATA record
+[`10.22002/4m9sp-yzr58`](https://doi.org/10.22002/4m9sp-yzr58), the open
+Zenodo records [`10.5281/zenodo.15685795`](https://doi.org/10.5281/zenodo.15685795)
+and [`10.5281/zenodo.19491381`](https://doi.org/10.5281/zenodo.19491381), and
+the primary articles linked below.
+
+## Topic 01 — Robust Rabi carrier and envelope recovery
+
+### Research question
+
+Which bounded envelope family best predicts unseen state-\(|1\rangle\)
+populations while preserving a stable microwave Rabi carrier?
+
+### Evidence that the gap is open
+
+CaltechDATA publishes 80 durations, processed populations, and one-sigma
+uncertainties for Fig. 4a. The article reports a 24.611 kHz carrier and
+attributes late-time decay to spatially varying Rabi frequency, but does not
+provide a reusable held-out model-selection benchmark.
+
+### Suitability
+
+- **Checkable:** 5/5 — deterministic sealed-duration prediction.
+- **Cheap:** 5/5 — 2.3 kB and seconds per fit.
+- **Headroom:** 4/5 — envelope, weighting, constraints, and search choices.
+- **Publishable:** 3/5 — strongest as a benchmark/method note.
+
+### Metrics
+
+- **Primary metric** — uncertainty-normalized RMSE on sealed durations.
+- **Guard metric** — complete finite populations in `[0,1]`, carrier in a
+  frozen physical interval, and unseen jittered-duration checks.
+
+### Cost and resources
+
+Standard-library Python is sufficient; 30 seconds and one CPU per attempt.
+
+### Gaming risk and negative control
+
+A row lookup can memorize the public scan. Randomize IDs and include
+perturbed durations unavailable as exact source rows.
+
+### Undergraduate prerequisites
+
+Driven two-level systems, least squares, basic Python, and train/test splits.
+
+## Topic 02 — Ramsey dephasing-family discrimination
+
+### Research question
+
+Can Gaussian, exponential, stretched-exponential, and site-mixture models be
+distinguished using unseen Ramsey evolution times and sites?
+
+### Evidence that the gap is open
+
+The same CaltechDATA record publishes evolution times and a 431.9 MB
+iteration-by-time-by-image-by-site presence tensor for Fig. 4b. The paper
+reports different array-averaged and site-resolved \(T_2^*\), leaving a clear
+model-selection and hierarchical-compression exercise.
+
+### Suitability
+
+- **Checkable:** 5/5 — held-out Bernoulli log loss by time and site.
+- **Cheap:** 3/5 — data are moderate, but minibatched scoring is simple.
+- **Headroom:** 5/5 — hierarchical, mixture, and robust dephasing models.
+- **Publishable:** 4/5 — reusable site-aware benchmark if splits are frozen.
+
+### Metrics
+
+- **Primary metric** — sealed-site-and-time Bernoulli negative log likelihood.
+- **Guard metric** — calibrated probabilities, coverage on unseen sites, and
+  no site-ID lookup.
+
+### Cost and resources
+
+About 432 MB storage; CPU streaming with a memory ceiling below 2 GB.
+
+### Gaming risk and negative control
+
+Site memorization can look predictive. Seal entire sites and late times, then
+test a candidate that keys only on site index.
+
+### Undergraduate prerequisites
+
+Ramsey interferometry, Bernoulli likelihoods, vectorized array processing.
+
+## Topic 03 — Dynamical-decoupling contrast model selection
+
+### Research question
+
+Which constrained contrast-decay law best extrapolates the two analyzer-phase
+branches of the Fig. 4c dynamical-decoupling scan?
+
+### Evidence that the gap is open
+
+CaltechDATA provides time, population, and uncertainty arrays for both final
+phases; the paper quotes \(T_2=12.6(1)\) s but does not benchmark competing
+finite-contrast and drift-aware observation models.
+
+### Suitability
+
+- **Checkable:** 5/5 — tiny arrays with uncertainty-aware holdout.
+- **Cheap:** 5/5 — less than 1 kB.
+- **Headroom:** 4/5 — shared/asymmetric envelopes and nuisance offsets.
+- **Publishable:** 3/5 — a compact reproducibility and identifiability study.
+
+### Metrics
+
+- **Primary metric** — normalized RMSE on sealed times and phases.
+- **Guard metric** — positive \(T_2\), phase-consistent contrast, populations
+  in `[0,1]`, and parameter stability under leave-one-time-out fits.
+
+### Cost and resources
+
+No GPU; exhaustive small-model search fits within seconds.
+
+### Gaming risk and negative control
+
+Independent interpolation of each phase can violate shared physics. Include a
+control that fits each branch separately and reject inconsistent contrast.
+
+### Undergraduate prerequisites
+
+Spin echo/dynamical decoupling, exponential models, uncertainty propagation.
+
+## Topic 04 — Global randomized-benchmarking decay inference
+
+### Research question
+
+Can hierarchical sequence-to-sequence variation improve prediction of unseen
+Clifford lengths over a single averaged exponential decay?
+
+### Evidence that the gap is open
+
+Fig. 4d source arrays expose length, return probability, uncertainty, and
+random-sequence axes. The paper reports an average Clifford fidelity but the
+public data support a checkable comparison of pooled and hierarchical
+observation models.
+
+### Suitability
+
+- **Checkable:** 5/5 — seal complete random sequences and lengths.
+- **Cheap:** 5/5 — roughly 15 kB.
+- **Headroom:** 4/5 — heterogeneity, robust likelihoods, and finite-SPAM fits.
+- **Publishable:** 4/5 — useful small-data RB benchmark.
+
+### Metrics
+
+- **Primary metric** — held-out normalized RMSE or beta-likelihood deviance.
+- **Guard metric** — decay parameter in `[0,1]`, finite SPAM parameters, and
+  accuracy on unseen sequence identities.
+
+### Cost and resources
+
+CPU-only, under one minute per attempt.
+
+### Gaming risk and negative control
+
+Memorizing each random string defeats interpolation. Seal whole strings and
+include a per-string lookup-table control.
+
+### Undergraduate prerequisites
+
+Randomized benchmarking, exponential decay, hierarchical regression.
+
+## Topic 05 — Transport survival surface with confidence bounds
+
+### Research question
+
+Which monotone or shape-constrained surrogate best predicts straight and
+diagonal atom-survival probability at unseen move durations?
+
+### Evidence that the gap is open
+
+CaltechDATA Fig. 5a provides duration plus central/lower/upper survival
+estimates for both geometries. The article reports optimized operation points,
+not a benchmark of uncertainty-aware surrogate families.
+
+### Suitability
+
+- **Checkable:** 5/5 — duration holdout with explicit confidence intervals.
+- **Cheap:** 5/5 — about 2.2 kB.
+- **Headroom:** 4/5 — splines, constrained kernels, and mechanistic losses.
+- **Publishable:** 3/5 — reusable surrogate-selection exercise.
+
+### Metrics
+
+- **Primary metric** — interval-normalized RMSE on sealed durations.
+- **Guard metric** — survival in `[0,1]`, correct geometry labels, and
+  prespecified smoothness/shape constraints.
+
+### Cost and resources
+
+Seconds per attempt with standard numerical tools.
+
+### Gaming risk and negative control
+
+High-order interpolation can oscillate between rows. Add midpoint queries and
+reject out-of-range or excessive-curvature predictions.
+
+### Undergraduate prerequisites
+
+Probability, confidence intervals, interpolation, constrained optimization.
+
+## Topic 06 — Coherence loss under transport
+
+### Research question
+
+Can a shared-phase observation model separate contrast loss from phase shift
+between static and transported Ramsey fringes?
+
+### Evidence that the gap is open
+
+CaltechDATA Fig. 5b publishes analyzer phase and confidence-bounded
+populations for static and transported cases. A single quoted transport
+fidelity does not determine whether contrast, offset, or phase is responsible.
+
+### Suitability
+
+- **Checkable:** 5/5 — held-out analyzer phases.
+- **Cheap:** 5/5 — about 1.1 kB.
+- **Headroom:** 4/5 — coupled sinusoidal and circular-statistics models.
+- **Publishable:** 3/5 — bounded observation-model result.
+
+### Metrics
+
+- **Primary metric** — confidence-normalized prediction error on sealed phases.
+- **Guard metric** — periodic continuity, populations in `[0,1]`, and a
+  bootstrap interval for transported/static contrast ratio.
+
+### Cost and resources
+
+CPU-only; bootstrap capped at a frozen number of resamples.
+
+### Gaming risk and negative control
+
+Phase-index interpolation ignores periodicity. Seal across the \(0/2\pi\)
+boundary and test a nonperiodic spline control.
+
+### Undergraduate prerequisites
+
+Ramsey fringes, trigonometric regression, bootstrap confidence intervals.
+
+## Topic 07 — Survival versus coherent return in repeated transport
+
+### Research question
+
+Can a joint observation model separate atom loss from conditional coherent
+return across move duration and number of repeated moves?
+
+### Evidence that the gap is open
+
+CaltechDATA Fig. 5d publishes a duration-by-move-count survival tensor and
+static/transported return probabilities with uncertainties. These observables
+constrain different processes, but a unique microscopic channel is not
+directly identifiable.
+
+### Suitability
+
+- **Checkable:** 5/5 — two-output sealed grid prediction.
+- **Cheap:** 5/5 — about 2 kB.
+- **Headroom:** 5/5 — joint hazards, conditional returns, and change points.
+- **Publishable:** 4/5 — explicit identifiability-aware benchmark.
+
+### Metrics
+
+- **Primary metric** — weighted joint RMSE for survival and return probability.
+- **Guard metric** — both outputs in `[0,1]`, nonnegative loss hazard, and
+  correct performance on unseen duration/count combinations.
+
+### Cost and resources
+
+Small-grid CPU fitting under 30 seconds.
+
+### Gaming risk and negative control
+
+Multiplying two independent fitted curves can misstate conditional coherence.
+Include that factorized model as a negative control and seal grid rectangles.
+
+### Undergraduate prerequisites
+
+Conditional probability, survival models, two-output regression.
+
+## Topic 08 — Hand-designed versus ML transport-transfer trajectories
+
+### Research question
+
+Can a low-parameter model predict survival and return-probability trade-offs
+for hand-optimized and ML-optimized static/dynamic tweezer transfers?
+
+### Evidence that the gap is open
+
+CaltechDATA Fig. 6d provides survival and return-probability arrays across
+trajectory/duration choices and repeated transfers, including an ML-optimized
+0.4 ms case. The open comparison supports a blinded surrogate benchmark.
+
+### Suitability
+
+- **Checkable:** 5/5 — seal a trajectory-duration family.
+- **Cheap:** 5/5 — about 1.2 kB.
+- **Headroom:** 4/5 — partial pooling, interaction terms, monotone hazards.
+- **Publishable:** 4/5 — transparent ML-versus-hand-designed comparison.
+
+### Metrics
+
+- **Primary metric** — held-out joint normalized RMSE across move counts.
+- **Guard metric** — calibrated uncertainty, valid probabilities, and no
+  trajectory-name lookup.
+
+### Cost and resources
+
+CPU-only; candidate source capped at a small dependency lock.
+
+### Gaming risk and negative control
+
+The label “ML optimized” leaks rank. Replace names with randomized IDs and
+include a candidate that predicts solely from the label as a control.
+
+### Undergraduate prerequisites
+
+Regression interactions, survival probability, experimental controls.
+
+## Topic 09 — Gate-speed error-budget response fitting
+
+### Research question
+
+Which constrained response model best predicts CZ fidelity across Rabi speed
+while separating frequency noise, intensity noise, decay, and rise/fall
+effects only to the extent supported by published observables?
+
+### Evidence that the gap is open
+
+Tsai et al., *PRX Quantum* **6**, 010331 (2025), DOI
+`10.1103/PRXQuantum.6.010331`, reports gate-speed sweeps, an ab-initio error
+model, and fidelity-response scaling. Reproducing tables/curves still leaves
+room for a compact held-out surrogate and a transparent identifiability audit.
+
+### Suitability
+
+- **Checkable:** 4/5 — blind selected speeds/table entries.
+- **Cheap:** 4/5 — small published tables; no full many-body simulation.
+- **Headroom:** 5/5 — scaling priors and constrained component models.
+- **Publishable:** 4/5 — useful if digitization/provenance is released.
+
+### Metrics
+
+- **Primary metric** — held-out fidelity error across Rabi frequencies.
+- **Guard metric** — nonnegative component infidelities, total-budget
+  consistency, and explicit “bound-only” labels for nonidentifiable parts.
+
+### Cost and resources
+
+One-time table extraction; seconds to minutes per fit.
+
+### Gaming risk and negative control
+
+Residual infidelity cannot all be called coherent error. Reject candidates
+that equate residual with a uniquely identified coherent channel; include
+that overclaim as a semantic negative control.
+
+### Undergraduate prerequisites
+
+Rydberg CZ gates, error budgets, power laws, constrained regression.
+
+## Topic 10 — Active pulse-time sampling for identifiability
+
+### Research question
+
+Given a fixed measurement budget, which next Rabi or Ramsey time most reduces
+uncertainty between competing envelope families?
+
+### Evidence that the gap is open
+
+The open Fig. 4a/4c grids permit an offline pool-based active-learning
+benchmark: hide most times, let a policy acquire labels sequentially, and
+score on a permanently sealed set. The source articles optimize physical
+operations, not this acquisition-policy comparison.
+
+### Suitability
+
+- **Checkable:** 5/5 — fixed acquisition budget and sealed final grid.
+- **Cheap:** 5/5 — reuse sub-kilobyte processed arrays.
+- **Headroom:** 5/5 — variance, disagreement, information-gain policies.
+- **Publishable:** 4/5 — reusable small-data active-design benchmark.
+
+### Metrics
+
+- **Primary metric** — area under held-out error versus acquired-label curve.
+- **Guard metric** — exact acquisition budget, no access to unqueried labels,
+  deterministic seeds, and correct uncertainty coverage.
+
+### Cost and resources
+
+Hundreds of short CPU simulations; no laboratory access required.
+
+### Gaming risk and negative control
+
+An offline policy can accidentally inspect the full label pool. Serve labels
+through a metered oracle and test a policy that directly opens the source
+array; the sandbox must reject it.
+
+### Undergraduate prerequisites
+
+Experimental design, uncertainty, greedy algorithms, reproducible simulation.

--- a/skills/autoresearch-db/SKILL.md
+++ b/skills/autoresearch-db/SKILL.md
@@ -20,10 +20,16 @@ available user-input mechanism.
    areas an idea-proposer needs: algorithmic techniques, proof/analysis
    methods, data structures, benchmark practices for this problem class.
    Resolve user approval of the list before downloading anything.
-2. **Download for coverage.** Acquire references with the `download-ref`
-   skill into `<project>/.knowledge/`. Coverage check: every insight area is
-   covered by ≥1 downloaded reference; areas with no coverage trigger
-   further search/downloads. SOTA-results-only coverage is insufficient.
+2. **Download for coverage.** Build the exact reference manifest needed to
+   cover the approved insight areas. Resolve a single approval decision that
+   covers both that manifest and the deterministic cite-key policy: accept
+   `download-ref`'s collision-free proposed keys, but stop on any collision
+   or missing proposal. Record the decision through the shared approval
+   contract, then acquire the references with the `download-ref` skill into
+   `<project>/.knowledge/`. An exact pre-authorized decision is consumed
+   without another prompt. Coverage check: every insight area is covered by
+   ≥1 downloaded reference; areas with no coverage trigger further
+   search/downloads. SOTA-results-only coverage is insufficient.
 3. **Distill.** For each insight area, write one entry in
    `research/INSIGHTS.md` following
    `skills/autoresearch-db/references/insights-template.md` (Technique /

--- a/skills/autoresearch-db/SKILL.md
+++ b/skills/autoresearch-db/SKILL.md
@@ -9,13 +9,17 @@ Input: a topic with metrics in `topics.md`. Output: a knowledge base, an
 insight file, a domain database, pinned reference code, a catalog — and the
 survey gate passed. The point is not "papers exist on disk" but "the agent
 holds the insights needed to *propose new ideas*".
+Resolve insight-map and Selected/Shelved choices through
+`skills/autoresearch/references/approval-contract.md`. Consume an exact
+pre-authorized decision without prompting; otherwise use the platform's
+available user-input mechanism.
 
 ## Procedure
 
 1. **Map insight areas.** From the topic and its metrics, list the insight
    areas an idea-proposer needs: algorithmic techniques, proof/analysis
    methods, data structures, benchmark practices for this problem class.
-   Show the list to the user before downloading anything.
+   Resolve user approval of the list before downloading anything.
 2. **Download for coverage.** Acquire references with the `download-ref`
    skill into `<project>/.knowledge/`. Coverage check: every insight area is
    covered by ≥1 downloaded reference; areas with no coverage trigger
@@ -25,10 +29,11 @@ holds the insights needed to *propose new ideas*".
    `skills/autoresearch-db/references/insights-template.md` (Technique /
    Applies when / Limits / Sources). Distill from the rendered papers in
    `.knowledge/`, not from memory.
-4. **User selects.** Present the distilled areas via `AskUserQuestion`
-   (multi-select): which are needed for idea generation on this topic?
-   Selected entries go under `## Selected`, the rest under `## Shelved`.
-   The run loop draws only on Selected.
+4. **User selects.** Resolve which distilled areas are needed for idea
+   generation through
+   `skills/autoresearch/references/approval-contract.md`. Selected entries go
+   under `## Selected`, the rest under `## Shelved`. The run loop draws only
+   on Selected.
 5. **Domain database.** Build the structured dataset the topic needs (e.g.
    QEC codes as JSON) under `research/database/`, with a `README.md`
    documenting schema and provenance of every record.

--- a/skills/autoresearch-run/SKILL.md
+++ b/skills/autoresearch-run/SKILL.md
@@ -23,8 +23,9 @@ gate is never worked around; a user-approved exception goes into
 
 Run all checks before planning the first attempt:
 
-1. `git check-ignore -q .worktrees` must succeed. If it fails, refuse to
-   create worktrees until `.worktrees/` is ignored and that rule is committed.
+1. `git check-ignore -q --no-index .worktrees/` must succeed even before the
+   directory exists. If it fails, refuse to create worktrees until
+   `.worktrees/` is ignored and that rule is committed.
 2. `git status --porcelain --untracked-files=all` must be empty. Ignored
    private validator/holdout files do not appear; any uncommitted public pipeline artifacts
    are a refusal condition.

--- a/skills/autoresearch-run/SKILL.md
+++ b/skills/autoresearch-run/SKILL.md
@@ -8,7 +8,7 @@ description: Use when running the autoresearch loop for a project whose survey a
 The loop. Protocol per attempt: `references/attempt-protocol.md`. Report per
 cycle: `references/reflection-template.md`. Configuration from
 `research/STATE.md`: `batch_size` (default 10), `time_limit_seconds`,
-`authorized_rounds`, `next_attempt`, `next_cycle`.
+`authorized_rounds`, `next_attempt`, `next_cycle`, `baseline_commit`.
 
 ## Entry check — refuse to start otherwise
 
@@ -19,9 +19,30 @@ not, refuse and route back through the `autoresearch` dispatcher. A missing
 gate is never worked around; a user-approved exception goes into
 `overrides:` in STATE.md first.
 
+## Committed baseline preflight — refuse on any failure
+
+Run all checks before planning the first attempt:
+
+1. `git check-ignore -q .worktrees` must succeed. If it fails, refuse to
+   create worktrees until `.worktrees/` is ignored and that rule is committed.
+2. `git status --porcelain --untracked-files=all` must be empty. Ignored
+   private validator/holdout files do not appear; any uncommitted public pipeline artifacts
+   are a refusal condition.
+3. `baseline_commit` must resolve to a commit and
+   `git merge-base --is-ancestor <baseline_commit> HEAD` must succeed. The
+   baseline names the immutable candidate-visible public tree; a later clean
+   orchestration commit may record the SHA in STATE.md.
+4. Verify `topics.md`, `research/CATALOG.md`, `research/INSIGHTS.md`,
+   `research/database/`, `research/benchmark/dev/`, and the public validator
+   contract exist in `baseline_commit`. Refuse if the current public pipeline
+   artifacts differ from that baseline except for orchestration-owned state
+   and reports.
+
 ## Hard rules (non-negotiable during the loop)
 
-1. Every attempt in its own `.worktrees/attempt-NNN/` with a `LOG.md`.
+1. Every attempt in its own explicitly named
+   `autoresearch/attempt-NNN` branch and `.worktrees/attempt-NNN/` with a
+   `LOG.md`; its parent ref follows `references/attempt-protocol.md`.
 2. Every scored run goes through the validator CLI; nothing else counts.
 3. Hard wall-clock limit `time_limit_seconds` on every scored run.
 4. Holdout labels never enter design context — only aggregate validator

--- a/skills/autoresearch-run/references/attempt-protocol.md
+++ b/skills/autoresearch-run/references/attempt-protocol.md
@@ -2,29 +2,47 @@
 
 Every attempt, no exceptions:
 
-1. **Worktree.** `git worktree add .worktrees/attempt-NNN` (NNN from
-   `next_attempt` in STATE.md, zero-padded to 3 digits; increment
-   immediately; numbers are never reused, even for crashes).
+1. **Resolve lineage and create the worktree.** NNN comes from `next_attempt`
+   in STATE.md, zero-padded to 3 digits; increment it immediately and never
+   reuse a number, even for crashes. Resolve `<parent-ref>` before creation:
+   - `draft` → `baseline_commit` from STATE.md;
+   - `improve` → **result commit** of the named successful parent attempt;
+   - `debug` → **result commit** of the named failed parent attempt.
+
+   Verify the ref exists, then run
+   `git worktree add -b autoresearch/attempt-NNN .worktrees/attempt-NNN <parent-ref>`.
 2. **LOG.md first.** Before writing code, create `LOG.md` in the worktree:
    - attempt number and date;
    - **kind** — `draft` | `improve` | `debug`;
    - **parent** — for `improve`/`debug`, the ancestor attempt number this
      builds on (`none` for drafts). Lineage is how later batches know which
      branch a result belongs to;
+   - **base commit** — the resolved full SHA of `<parent-ref>`;
+   - **result commit** — initially `(pending)`;
    - **hypothesis** — the idea being tried, naming which `## Selected`
      insight(s) from `research/INSIGHTS.md` it draws on; for `improve`, the
      single atomic change being made;
    - **expected evidence** — what result would confirm or kill it.
 3. **Implement** the candidate in the worktree. It may read dev instances
-   and everything in `research/` except `benchmark/private/`. Use
+   and public research artifacts, but neither `benchmark/private/` nor
+   `validator/private/`. Use
    `validate --precheck` freely while developing — it checks structure and
    format without revealing a score and does not consume anything.
 4. **Score** by invoking the validator CLI (`validate <worktree>`), which
    enforces `time_limit_seconds` and the environment. Nothing else counts
    as a result — no eyeballed timings, no partial credit.
-5. **Record outcome** in LOG.md: the validator's JSON summary (score,
+5. **Record outcome and commits** in LOG.md: the validator's JSON summary (score,
    per-instance results, errors), plus what was learned — especially from
    failures. A crash or timeout is recorded as a failed attempt and is
-   never silently retried; retrying with a fix is a *new* attempt.
+   never silently retried; retrying with a fix is a *new* attempt. For a
+   completed candidate:
+   - commit candidate code plus the outcome log;
+   - capture that SHA as the **result commit** used by descendants;
+   - replace `(pending)` in LOG.md with the captured SHA and make a second,
+     log-only audit commit.
+
+   If no candidate commit exists because the attempt crashed before
+   implementation, set **result commit** to `(none—crashed)` and commit the
+   audit log only.
 6. **Leave the worktree intact.** Worktrees are the audit trail; reflection
    reads their LOG.md files.

--- a/skills/autoresearch-run/references/reflection-template.md
+++ b/skills/autoresearch-run/references/reflection-template.md
@@ -9,7 +9,8 @@ logs. Required sections:
     ## Yield
     Honest denominators, always: "K of N attempts improved the primary
     metric; best <value> vs prior best <value>." Per attempt, one line:
-    kind (draft/improve/debug), parent, metric, and a one-line causal claim.
+    kind (draft/improve/debug), parent, base/result commits, metric, and a
+    one-line causal claim.
     Rank which single change mattered most — that ranking targets the next
     batch's improvements.
 

--- a/skills/autoresearch-topics/SKILL.md
+++ b/skills/autoresearch-topics/SKILL.md
@@ -11,6 +11,10 @@ topic is one where a validator — not a human — can tell whether an attempt
 succeeded; the metrics defined here become that validator's score function in
 the validator stage, so gaming risks identified here turn into negative
 controls there.
+Resolve topic and metric choices through
+`skills/autoresearch/references/approval-contract.md`. Consume an exact
+pre-authorized decision without prompting; otherwise use the platform's
+available user-input mechanism.
 
 ## Procedure
 
@@ -31,7 +35,8 @@ controls there.
      publishable result.
    Present the scored table; flag any candidate scoring ≤2 on Checkable or
    Cheap as unsuitable and say why.
-4. **User picks** topics via `AskUserQuestion` (multi-select) from the table.
+4. **User picks.** Resolve the topic selection through
+   `skills/autoresearch/references/approval-contract.md` from the scored table.
 5. **Derive metrics** for each chosen topic, one at a time. Propose 2–5
    candidate metrics; for each, state:
    - **Definition** — the quantity, precisely enough to implement.
@@ -42,8 +47,8 @@ controls there.
    Classify each as **primary** (enters the score function — usually one per
    topic, e.g. wall-clock speedup at verified-exact output) or **guard**
    (anti-gaming side condition, e.g. exactness on unseen instances, no
-   hard-coded answers). The user approves the metric set per topic
-   (`AskUserQuestion`; amendments welcome).
+   hard-coded answers). Resolve user approval of the metric set per topic
+   through the same approval contract; amendments are welcome.
 6. **Write `topics.md`.** One `## <topic title>` section per chosen topic:
    problem statement, why autoresearch fits (the four scores), key references
    (title + arXiv ID/DOI), and a `### Metrics` block — one bullet per

--- a/skills/autoresearch-validator/SKILL.md
+++ b/skills/autoresearch-validator/SKILL.md
@@ -9,12 +9,17 @@ Goal: once the validator's bar is met, the result is publishable — so the
 validator must be impossible to satisfy by accident or by cheating. Contract
 details: `references/validator-contract.md`; strictness self-test:
 `references/negative-controls.md`.
+Resolve the publishable bar and any environment fallback through
+`skills/autoresearch/references/approval-contract.md`. Consume an exact
+pre-authorized decision without prompting; otherwise use the platform's
+available user-input mechanism.
 
 ## Procedure
 
-1. **Define the publishable bar** with the user: a goal statement naming the
-   primary metric (from `topics.md`), the threshold, and the instance
-   families it must hold on. Write it to `research/validator/GOAL.md`.
+1. **Define the publishable bar.** Resolve the user's exact goal statement
+   through `skills/autoresearch/references/approval-contract.md`; it names the
+   primary metric (from `topics.md`), the threshold, and the instance families
+   it must hold on. Write it to `research/validator/GOAL.md`.
 2. **Split instances.** Development instances (visible to attempts) vs a
    **sealed holdout** under `research/benchmark/private/`:
    - add `research/benchmark/private/` to `.gitignore`;

--- a/skills/autoresearch-validator/SKILL.md
+++ b/skills/autoresearch-validator/SKILL.md
@@ -22,7 +22,15 @@ available user-input mechanism.
    it must hold on. Write it to `research/validator/GOAL.md`.
 2. **Split instances.** Development instances (visible to attempts) vs a
    **sealed holdout** under `research/benchmark/private/`:
-   - add `research/benchmark/private/` to `.gitignore`;
+   - use this layout:
+     - `research/benchmark/dev/` — tracked public inputs;
+     - `research/benchmark/private/` — ignored holdout inputs and labels;
+     - `research/validator/` — tracked public launcher, contract, and
+       manifest; and
+     - `research/validator/private/` — ignored scorer core and expected
+       values;
+   - add both `research/benchmark/private/` and
+     `research/validator/private/` to `.gitignore`;
    - seal **by construction, not convention**: the validator runs as a
      separate process outside the attempt worktree, the holdout is mounted
      read-only into the validator environment only, and neither the holdout
@@ -42,7 +50,10 @@ available user-input mechanism.
    unavailable or unsuitable (e.g. HPC-only toolchain), fall back to a
    locked venv + subprocess sandbox and record
    `validator_env: fallback (<reason>)` in STATE.md and in the manifest —
-   never fall back silently.
+   never fall back silently. Hash the scorer, holdout, and sandbox policy in
+   the manifest. Before opening the gate, run a candidate-process probe for
+   both private roots and network access; if any probe succeeds, **fail closed**.
+   A prompt-only instruction is not a sandbox.
 4. **Implement the `validate` CLI** per `references/validator-contract.md`,
    under `research/validator/`. Guard metrics from `topics.md` become
    rejection rules. Include the free `--precheck` mode (structure/format
@@ -63,6 +74,9 @@ Flip `validator_gate: passed <date>` and set `stage: run` in
 - `GOAL.md` states the bar in terms of the primary metric;
 - the holdout is sealed (gitignored, labels unopened) with provenance in the
   manifest;
+- the scorer and holdout are outside the attempt worktree, their hashes and
+  sandbox policy hash are in the manifest, and the candidate-process privacy
+  probe fails closed on every forbidden read and network attempt;
 - `validate` runs end-to-end on a trivial baseline candidate against dev
   instances;
 - every negative control is rejected with a specific `errors[]` entry;

--- a/skills/autoresearch-validator/references/negative-controls.md
+++ b/skills/autoresearch-validator/references/negative-controls.md
@@ -10,12 +10,17 @@ self-test results are recorded in `research/validator/manifest.json`.
 | `cheater` | returns hard-coded answers for the dev instances (e.g. a lookup table keyed on instance id or input hash) | reject: guard metrics / unseen-instance check catches it |
 | `wrong-answer` | runs plausibly but returns an incorrect result on ≥1 instance | reject: exactness check fails, error names the instance and the wrong value |
 | `timeout` | busy-loops past the wall-clock limit | mark `timeout` on the instance, enforce the limit with margin <5% overshoot, score accordingly |
-| `env-escape` | attempts network access or reads outside the candidate dir (e.g. tries to open the holdout labels) | reject: the environment blocks it and the report says what was attempted |
+| `env-escape` | separately attempts network access, a read of `research/validator/private/`, and a read of `research/benchmark/private/` | reject: all three probes are blocked and the report names each attempted boundary |
 
 Rules:
 
 - Controls are written *before* the first real attempt and kept working; a
   validator change that stops rejecting any control re-opens the gate.
+- The `env-escape` control must run real probes equivalent to:
+  `open("../research/validator/private/scorer.py", "rb")`,
+  `open("../research/benchmark/private/labels.json", "rb")`, and
+  `socket.create_connection(("example.com", 80), timeout=1)`. A validator
+  fails closed if any private read or network connection succeeds.
 - When a new hack is discovered during the run loop, **patch the validator
   harness and add a control reproducing the hack** — never respond by adding
   "do not cheat" instructions to attempt prompts (measured to be near-useless

--- a/skills/autoresearch-validator/references/validator-contract.md
+++ b/skills/autoresearch-validator/references/validator-contract.md
@@ -61,3 +61,27 @@ instance, the observed vs expected behavior, and the first thing to check.
 
 Guard metrics from `topics.md` (anti-gaming conditions) are enforced here as
 rejection rules, not reported as soft warnings.
+
+## Private boundary and manifest
+
+The public launcher and manifest live under `research/validator/`. The scorer
+core and private expected values live under
+`research/validator/private/`; holdout inputs and labels live under
+`research/benchmark/private/`. Both private directories are gitignored,
+outside the attempt worktree, and readable only by the validator process.
+
+The manifest records immutable digests without exposing content:
+
+```json
+{
+  "scorer_hash": "sha256:<hex>",
+  "holdout_hash": "sha256:<hex>",
+  "sandbox_policy_hash": "sha256:<hex>"
+}
+```
+
+Attempts and reflection receive aggregate holdout pass/fail, never labels.
+Before the validator gate passes, the `env-escape` control must prove that a
+candidate process cannot read either private root or open a network
+connection. If any forbidden probe succeeds, fail closed and leave the gate
+pending.

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -9,6 +9,10 @@ Pipeline: `autoresearch-topics` → `autoresearch-db`
 → `autoresearch-validator` → `autoresearch-run`. State lives in
 `<project>/research/STATE.md` (schema and template:
 `skills/autoresearch/references/state-schema.md`).
+Resolve every stage choice through
+`skills/autoresearch/references/approval-contract.md`; exact
+pre-authorizations are consumed without asking again and all decisions are
+recorded in the approval log.
 
 ## Procedure
 
@@ -18,8 +22,9 @@ Pipeline: `autoresearch-topics` → `autoresearch-db`
      `autoresearch-topics`.
    - **Corrupt/unreadable** → re-derive the stage from the artifact table
      below (earliest stage whose required artifacts are missing), show the
-     user the derived state, and confirm with them before overwriting
-     STATE.md. Never overwrite a readable STATE.md.
+     user the derived state, and resolve confirmation through
+     `references/approval-contract.md` before overwriting STATE.md. Never
+     overwrite a readable STATE.md.
 2. **Verify, don't trust.** Check the artifacts the recorded stage implies.
    If any are missing, drop back to the earliest stage whose artifacts are
    missing and tell the user what was expected and not found.

--- a/skills/autoresearch/references/approval-contract.md
+++ b/skills/autoresearch/references/approval-contract.md
@@ -1,0 +1,20 @@
+# Stage approval contract
+
+Every stage decision is explicit and auditable.
+
+1. Check the current conversation for an exact decision that names the
+   selected item or approved configuration.
+2. Check `research/APPROVALS.md` when `approval_log:` in `STATE.md` points to
+   it. A valid entry records UTC date, stage, decision, scope, and provenance
+   (`conversation` or `approval-log`).
+3. If the exact decision is already pre-authorized, copy it into the approval
+   log and continue without asking again.
+4. Otherwise use the platform's available user-input mechanism.
+   `AskUserQuestion` is one implementation, not a required tool; plain chat or
+   another native picker is valid.
+5. Never infer approval from silence, a broad project goal, or approval of a
+   different metric or stage.
+
+Changing a recorded decision requires a new append-only entry. Protocol
+deviations still belong under `overrides:` in STATE.md; an approval is not an
+override.

--- a/skills/autoresearch/references/approval-contract.md
+++ b/skills/autoresearch/references/approval-contract.md
@@ -7,8 +7,10 @@ Every stage decision is explicit and auditable.
 2. Check `research/APPROVALS.md` when `approval_log:` in `STATE.md` points to
    it. A valid entry records UTC date, stage, decision, scope, and provenance
    (`conversation` or `approval-log`).
-3. If the exact decision is already pre-authorized, copy it into the approval
-   log and continue without asking again.
+3. If the current conversation contains an exact decision that is
+   pre-authorized but not yet logged, append it once and continue. If the
+   exact decision already exists in the approval log, reuse that entry; do
+   not duplicate it.
 4. Otherwise use the platform's available user-input mechanism.
    `AskUserQuestion` is one implementation, not a required tool; plain chat or
    another native picker is valid.

--- a/skills/autoresearch/references/state-schema.md
+++ b/skills/autoresearch/references/state-schema.md
@@ -15,6 +15,7 @@ keep them):
     - authorized_rounds: 0     # cycles the loop may run without user review
     - next_attempt: 1          # next .worktrees/attempt-NNN number
     - next_cycle: 1            # next reflection cycle number
+    - approval_log: research/APPROVALS.md  # append-only explicit decisions
     - gates:
       - survey_gate: pending     # pending | passed YYYY-MM-DD
       - validator_gate: pending  # pending | passed YYYY-MM-DD
@@ -28,5 +29,7 @@ Rules:
   checklist verifies on disk.
 - `overrides:` is append-only. Any deviation from the hard protocol rules must
   be recorded here with a date and reason; skills never deviate silently.
+- `approval_log:` points to the append-only decision record governed by
+  `approval-contract.md`. An approval is not a protocol override.
 - `attempt-NNN` numbering is zero-padded to 3 digits and never reused, even
   for crashed attempts.

--- a/skills/autoresearch/references/state-schema.md
+++ b/skills/autoresearch/references/state-schema.md
@@ -15,6 +15,7 @@ keep them):
     - authorized_rounds: 0     # cycles the loop may run without user review
     - next_attempt: 1          # next .worktrees/attempt-NNN number
     - next_cycle: 1            # next reflection cycle number
+    - baseline_commit: (unset) # immutable candidate-visible public baseline
     - approval_log: research/APPROVALS.md  # append-only explicit decisions
     - gates:
       - survey_gate: pending     # pending | passed YYYY-MM-DD
@@ -31,5 +32,9 @@ Rules:
   be recorded here with a date and reason; skills never deviate silently.
 - `approval_log:` points to the append-only decision record governed by
   `approval-contract.md`. An approval is not a protocol override.
+- `baseline_commit:` is captured from the committed candidate-visible public
+  tree before attempts start. A later clean orchestration commit records that
+  SHA in STATE.md; the baseline must be its ancestor, not a self-referential
+  copy of the orchestration HEAD.
 - `attempt-NNN` numbering is zero-padded to 3 digits and never reused, even
   for crashed attempts.

--- a/skills/download-ref/SKILL.md
+++ b/skills/download-ref/SKILL.md
@@ -177,9 +177,25 @@ PDF backend priority:
 
 `.raw/` and `.figures/` should stay out of git. Append to `.gitignore` if missing.
 
-### 6. Propose + confirm cite key (per ref, single-shot mode only)
+### 6. Propose + confirm cite key
 
-In single-shot mode (Step 3a), ask the user to confirm each new cite key. In bulk mode (Step 3b), the keys come from `references.bib` directly — skip this step.
+There are three approval modes:
+
+1. **Single-shot:** ask the user to confirm each new cite key.
+2. **Bulk from BibTeX:** keys already come from `references.bib`; skip this
+   step.
+3. **Pre-authorized direct batch:** a pre-authorized direct batch is one where
+   the caller supplies an auditable approval record naming the exact IDs/DOIs
+   and authorizing the deterministic collision-free proposals produced below.
+   Verify every proposed key is non-empty, unique within the batch, and absent
+   from the existing BibTeX. Then append without per-reference prompting.
+   Record the final mapping of reference ID to cite key in the caller's
+   approval log. A cite-key collision, missing proposal, or manifest mismatch
+   invalidates the batch approval and requires user confirmation; never
+   silently invent a replacement.
+
+Direct input defaults to single-shot mode unless the exact pre-authorized
+direct batch record is present.
 
 ```sh
 python3 skills/download-ref/helpers/append_bibtex.py propose \

--- a/tests/test_autoresearch_skills.py
+++ b/tests/test_autoresearch_skills.py
@@ -114,6 +114,24 @@ def test_db_delegates_paper_acquisition_to_download_ref():
     assert ".knowledge" in text
 
 
+def test_preapproved_db_batch_does_not_reprompt_for_each_cite_key():
+    db = _read("autoresearch-db")
+    download = _read("download-ref").lower()
+    for marker in [
+        "exact reference manifest",
+        "deterministic cite-key policy",
+        "single approval decision",
+    ]:
+        assert marker in db
+    for marker in [
+        "pre-authorized direct batch",
+        "without per-reference prompting",
+        "cite-key collision",
+        "record the final mapping",
+    ]:
+        assert marker in download
+
+
 def test_db_checks_insight_coverage_before_distilling():
     text = _read("autoresearch-db")
     assert "insight area" in text.lower()

--- a/tests/test_autoresearch_skills.py
+++ b/tests/test_autoresearch_skills.py
@@ -331,6 +331,7 @@ def test_approval_contract_is_portable_and_auditable():
     assert "platform" in contract.lower()
     assert "pre-authorized" in contract
     assert "never infer" in contract.lower()
+    assert "do not duplicate" in contract.lower()
 
 
 def test_interactive_stages_use_shared_approval_contract():
@@ -385,7 +386,7 @@ def test_state_records_committed_attempt_baseline():
 def test_run_preflights_worktree_and_clean_baseline():
     text = _read("autoresearch-run")
     for marker in [
-        "git check-ignore -q .worktrees",
+        "git check-ignore -q --no-index .worktrees/",
         "git status --porcelain",
         "git merge-base --is-ancestor",
         "baseline_commit",

--- a/tests/test_autoresearch_skills.py
+++ b/tests/test_autoresearch_skills.py
@@ -331,7 +331,7 @@ def test_approval_contract_is_portable_and_auditable():
     assert "platform" in contract.lower()
     assert "pre-authorized" in contract
     assert "never infer" in contract.lower()
-    assert "do not duplicate" in contract.lower()
+    assert "do not duplicate" in " ".join(contract.lower().split())
 
 
 def test_interactive_stages_use_shared_approval_contract():

--- a/tests/test_autoresearch_skills.py
+++ b/tests/test_autoresearch_skills.py
@@ -355,3 +355,31 @@ def test_contract_records_private_hashes_without_labels():
     assert "holdout_hash" in text
     assert "sandbox_policy_hash" in text
     assert "never labels" in text.lower()
+
+
+# ---- reproducible attempt worktrees ----
+
+def test_state_records_committed_attempt_baseline():
+    text = _ref("autoresearch", "state-schema.md")
+    assert "baseline_commit:" in text
+
+
+def test_run_preflights_worktree_and_clean_baseline():
+    text = _read("autoresearch-run")
+    for marker in [
+        "git check-ignore -q .worktrees",
+        "git status --porcelain",
+        "git merge-base --is-ancestor",
+        "baseline_commit",
+        "public pipeline artifacts",
+        "refuse",
+    ]:
+        assert marker in text
+
+
+def test_attempt_creation_names_branch_and_parent_ref():
+    text = _ref("autoresearch-run", "attempt-protocol.md")
+    assert "git worktree add -b autoresearch/attempt-NNN" in text
+    assert "<parent-ref>" in text
+    assert "**base commit**" in text
+    assert "**result commit**" in text

--- a/tests/test_autoresearch_skills.py
+++ b/tests/test_autoresearch_skills.py
@@ -95,7 +95,8 @@ def test_topics_derives_primary_and_guard_metrics():
 
 def test_topics_lets_user_pick_and_advances_stage():
     text = _read("autoresearch-topics")
-    assert "AskUserQuestion" in text
+    assert "approval-contract.md" in text
+    assert "user" in text.lower()
     assert "stage: db" in text
 
 
@@ -122,7 +123,8 @@ def test_db_checks_insight_coverage_before_distilling():
 def test_db_distills_and_lets_user_select_insights():
     text = _read("autoresearch-db")
     assert "research/INSIGHTS.md" in text
-    assert "AskUserQuestion" in text
+    assert "approval-contract.md" in text
+    assert "user" in text.lower()
     assert "Shelved" in text
 
 
@@ -293,3 +295,34 @@ def test_claude_md_lists_all_autoresearch_skills():
     assert "**autoresearch**" in text
     for stage_skill in STAGE_SKILLS:
         assert stage_skill in text
+
+
+# ---- portability and auditable stage approvals ----
+
+def test_codex_install_links_real_skill_directories():
+    text = (ROOT / ".codex" / "INSTALL.md").read_text()
+    assert "skills/sci-brain" not in text
+    assert 'for skill in "$HOME/.codex/sci-brain/skills"/*' in text
+    assert 'ln -sfn "$skill"' in text
+
+
+def test_approval_contract_is_portable_and_auditable():
+    contract = _ref("autoresearch", "approval-contract.md")
+    assert "research/APPROVALS.md" in contract
+    assert "current conversation" in contract
+    assert "platform" in contract.lower()
+    assert "pre-authorized" in contract
+    assert "never infer" in contract.lower()
+
+
+def test_interactive_stages_use_shared_approval_contract():
+    for skill in [
+        "autoresearch",
+        "autoresearch-topics",
+        "autoresearch-db",
+        "autoresearch-validator",
+    ]:
+        text = _read(skill)
+        assert "approval-contract.md" in text
+    state = _ref("autoresearch", "state-schema.md")
+    assert "approval_log:" in state

--- a/tests/test_autoresearch_skills.py
+++ b/tests/test_autoresearch_skills.py
@@ -326,3 +326,32 @@ def test_interactive_stages_use_shared_approval_contract():
         assert "approval-contract.md" in text
     state = _ref("autoresearch", "state-schema.md")
     assert "approval_log:" in state
+
+
+# ---- enforceable validator privacy ----
+
+def test_validator_private_layout_is_outside_attempts():
+    text = _read("autoresearch-validator")
+    for marker in [
+        "research/validator/private/",
+        "research/benchmark/private/",
+        "outside the attempt worktree",
+        "fail closed",
+        "policy hash",
+    ]:
+        assert marker in text
+
+
+def test_env_escape_control_probes_both_private_roots():
+    text = _ref("autoresearch-validator", "negative-controls.md")
+    assert "validator/private" in text
+    assert "benchmark/private" in text
+    assert "network" in text
+
+
+def test_contract_records_private_hashes_without_labels():
+    text = _ref("autoresearch-validator", "validator-contract.md")
+    assert "scorer_hash" in text
+    assert "holdout_hash" in text
+    assert "sandbox_policy_hash" in text
+    assert "never labels" in text.lower()

--- a/tests/test_neutral_atom_autoresearch_example.py
+++ b/tests/test_neutral_atom_autoresearch_example.py
@@ -1,0 +1,41 @@
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TOPICS = ROOT / "examples" / "neutral-atom-autoresearch-topics.md"
+
+
+def test_topic_reserve_has_ten_validator_ready_topics():
+    text = TOPICS.read_text()
+    matches = list(re.finditer(r"^## Topic (\d{2})", text, re.MULTILINE))
+    assert [match.group(1) for match in matches] == [
+        "{:02d}".format(index) for index in range(1, 11)
+    ]
+    required_sections = [
+        "### Research question",
+        "### Evidence that the gap is open",
+        "### Suitability",
+        "### Metrics",
+        "### Cost and resources",
+        "### Gaming risk and negative control",
+        "### Undergraduate prerequisites",
+    ]
+    required_markers = [
+        "**Checkable:**",
+        "**Cheap:**",
+        "**Headroom:**",
+        "**Publishable:**",
+        "**Primary metric**",
+        "**Guard metric**",
+    ]
+    boundaries = [match.start() for match in matches] + [len(text)]
+    for index in range(10):
+        section = text[boundaries[index] : boundaries[index + 1]]
+        for marker in required_sections + required_markers:
+            assert marker in section
+        checkable = int(re.search(r"\*\*Checkable:\*\*\s*(\d)/5", section).group(1))
+        cheap = int(re.search(r"\*\*Cheap:\*\*\s*(\d)/5", section).group(1))
+        assert checkable >= 3
+        assert cheap >= 3

--- a/tests/test_neutral_atom_autoresearch_example.py
+++ b/tests/test_neutral_atom_autoresearch_example.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 TOPICS = ROOT / "examples" / "neutral-atom-autoresearch-topics.md"
+SMOKE = ROOT / "examples" / "neutral-atom-autoresearch-smoke"
 
 
 def test_topic_reserve_has_ten_validator_ready_topics():
@@ -39,3 +40,33 @@ def test_topic_reserve_has_ten_validator_ready_topics():
         cheap = int(re.search(r"\*\*Cheap:\*\*\s*(\d)/5", section).group(1))
         assert checkable >= 3
         assert cheap >= 3
+
+
+def test_smoke_report_contains_public_reproduction_evidence_only():
+    readme = (SMOKE / "README.md").read_text()
+    summary = (SMOKE / "run-summary.md").read_text()
+    for marker in [
+        "topics",
+        "survey gate",
+        "validator gate",
+        "attempt-001",
+        "attempt-002",
+        "attempt-003",
+        "baseline score",
+        "best development score",
+        "holdout",
+        "reflection",
+    ]:
+        assert marker in (readme + summary).lower()
+
+    manifest = json.loads((SMOKE / "source-manifest.json").read_text())
+    assert manifest["dataset_doi"] == "10.22002/4m9sp-yzr58"
+    expected = {
+        "fig4a_rabi_duration.npy": "93c6bd2d084f5c80075c75c8976fe765",
+        "fig4a_rabi_pop_1.npy": "a0432de3d76551610e2a795803eb82dd",
+        "fig4a_rabi_pop_1_std.npy": "7b95de05b41d1e05fdba72dc90b20334",
+    }
+    assert {item["filename"]: item["md5"] for item in manifest["files"]} == expected
+    serialized = json.dumps(manifest).lower()
+    for private_path in ["benchmark/private", "validator/private", ".worktrees"]:
+        assert private_path not in serialized


### PR DESCRIPTION
## Summary

- harden the four-stage autoresearch suite with portable approvals, a real Codex install path, sealed validator-private state, and reproducible attempt lineage
- eliminate repeated cite-key prompts for an exact pre-authorized reference batch
- add a complete neutral-atom Rabi-envelope smoke-test report and ten validator-ready undergraduate topic briefs

## Why

An end-to-end run on the official CaltechDATA Fig. 4a processed Rabi scan exposed four concrete workflow gaps:

1. the Codex installer targeted a nonexistent aggregate skill directory;
2. approvals were tied to a platform-specific input tool and could not consume exact pre-authorization portably;
3. validator privacy and worktree ancestry were described but not enforceably pinned;
4. a pre-approved reference batch still paused once per generated cite key.

The updated protocols make those decisions auditable, require both validator-private roots to be unreachable from candidate processes, hash the scorer/holdout/sandbox policy, and assign every attempt an explicit branch, base commit, and result commit.

## End-to-end evidence

The example run used:

- dataset DOI `10.22002/4m9sp-yzr58`
- three pinned Fig. 4a arrays with recorded MD5 hashes
- one cycle, three attempts, 30-second validator limit
- four negative controls: cheater, wrong-answer, timeout, and environment escape

Results:

- frozen undamped development baseline: `40.86068140668919`
- Gaussian winner: `4.372371385616318`
- exponential attempt: rejected by the `[0,1]` physical-range guard
- robust-weighting follow-up: `4.474516584277779`
- single sealed holdout query: `1.4843925406501801` versus baseline `37.3765738659451`

The report explicitly treats this as effective envelope recovery from processed populations, not unique microscopic coherent-error identification.

## Validation

- focused autoresearch and example tests: `50 passed`
- full suite on this branch: `123 passed, 7 failed`
- full suite on the untouched baseline: `111 passed, 7 failed`
- the identical seven pre-existing failures are six assertions against the absent `skills/ideas` package plus one stale `download-ref` path assertion
- `git diff --check` passes

## Notes

- The PR includes public source metadata and aggregate scores only.
- Private holdout labels, scorer state, and attempt worktrees are intentionally excluded.
- No reviewers have been requested.
