### PR TITLE
fix(survey-writer): center-align the article title

### DIFF
--- a/skills/survey-writer/template.typ
+++ b/skills/survey-writer/template.typ
@@ -69,7 +69,7 @@
 
 // ---- title --------------------------------------------------------------
 
-#heading(numbering: none)[#title]
+#align(center)[#heading(numbering: none)[#title]]
 
 #align(center)[
   #text(size: 12pt, weight: "semibold")[State-of-the-Art Review]


### PR DESCRIPTION
## Summary

The `survey-writer` Typst template rendered the article title left-aligned, while the subtitle, author, and date block directly beneath it were already centered. This wraps the title heading in `#align(center)` so the whole title block is consistent.

```diff
-#heading(numbering: none)[#title]
+#align(center)[#heading(numbering: none)[#title]]
```

## Test plan

- Compiled `skills/survey-writer/template.typ` with `typst compile` — no errors.
- Rendered page 1 to PNG and confirmed visually that the title is centered above the existing centered subtitle/author block.

`SKILL.md` carries no title-layout instructions, so `template.typ` is the only place the title is laid out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)