### PR TITLE
feat(download-ref): disambiguate cite keys on lastname_year_firstword collision

### DIFF
--- a/skills/download-ref/SKILL.md
+++ b/skills/download-ref/SKILL.md
@@ -183,10 +183,10 @@ In single-shot mode (Step 3a), ask the user to confirm each new cite key. In bul
 
 ```sh
 python3 skills/download-ref/helpers/append_bibtex.py propose \
-  --kb "$KB" --id 1806.08734 --type arxiv
+  --kb "$KB" --id 1806.08734 --type arxiv --bib "$KB/references.bib"
 ```
 
-Output JSON has `proposed_key` (form `lastname_year_firstkeyword`), `title`, `authors`, `year`, `bibtex_with_proposed_key`. Show the user via `AskUserQuestion`:
+Output JSON has `proposed_key` (form `lastname_year_firstkeyword`), `title`, `authors`, `year`, `bibtex_with_proposed_key`. With `--bib`, a key already present in the bib is disambiguated by walking to the next content word of the title (existing keys are never renamed). Show the user via `AskUserQuestion`:
 - Accept the proposed key
 - Use a custom key (free-text)
 - Skip this entry
@@ -259,7 +259,7 @@ After the done checklist passes, offer the pipeline's final stage:
 | Forgetting `--download-arxiv-pdfs` in Step 4 | Without it `full_text: no` and Step 5 has nothing to render. |
 | Using `arXiv:XXXX` with prefix or `vN` suffix | Strip both — manifest takes bare ids: `1806.08734`. |
 | Editing the rendered `.md` and losing it on re-render | Renderer overwrites without warning. Edit `.raw/` source or renderer logic. |
-| Cite-key collision with different content | Helper skips silently — investigate, re-run propose with a different key. |
+| Cite-key collision with different content | `append` skips silently. Propose with `--bib` so the key is disambiguated up front (next content word of the title). |
 | Drifting `--title` / `--source-note` between runs | `INDEX.md` regenerates wholesale; first-run values are canonical. Copy verbatim from existing `INDEX.md`. |
 
 ## Done checklist

--- a/skills/download-ref/helpers/append_bibtex.py
+++ b/skills/download-ref/helpers/append_bibtex.py
@@ -40,7 +40,10 @@ def extract_bibtex(meta: dict) -> str:
     return bib.strip()
 
 
-def propose_key(meta: dict) -> str:
+STOPWORDS = {"a", "an", "the", "of", "on", "for", "and", "to", "is", "in", "with"}
+
+
+def propose_key(meta: dict, bib_path=None) -> str:
     authors = meta.get("authors") or []
     last = "anon"
     if authors:
@@ -50,10 +53,22 @@ def propose_key(meta: dict) -> str:
             last = re.sub(r"[^a-z]", "", last) or "anon"
     year = str(meta.get("year") or "0000")
     title = (meta.get("title") or "").lower()
-    stop = {"a", "an", "the", "of", "on", "for", "and", "to", "is", "in", "with"}
-    words = [w for w in re.findall(r"[a-z]+", title) if w not in stop]
-    kw = words[0] if words else "ref"
-    return f"{last}_{year}_{kw}"
+    words = [w for w in re.findall(r"[a-z]+", title) if w not in STOPWORDS] or ["ref"]
+    # Collision rule: when `lastname_year_firstword` is already in the bib,
+    # walk to the NEXT content word of the title until the key is unique —
+    # keys stay mnemonic and keep their three-part shape, and the existing
+    # key is never renamed (renaming would break citations already written).
+    if bib_path is not None:
+        for w in words:
+            key = f"{last}_{year}_{w}"
+            if not already_in_bib(bib_path, key):
+                return key
+        # Identical titles (all words exhausted): letter suffix as a last resort.
+        for suffix in "bcdefgh":
+            key = f"{last}_{year}_{words[0]}{suffix}"
+            if not already_in_bib(bib_path, key):
+                return key
+    return f"{last}_{year}_{words[0]}"
 
 
 def replace_key(bibtex: str, new_key: str) -> str:
@@ -69,7 +84,7 @@ def already_in_bib(bib_path: Path, key: str) -> bool:
 def cmd_propose(args):
     meta = load_meta(Path(args.kb), args.type, args.id)
     bib = extract_bibtex(meta)
-    key = propose_key(meta)
+    key = propose_key(meta, Path(args.bib) if args.bib else None)
     out = {
         "id": args.id,
         "type": args.type,
@@ -103,6 +118,8 @@ def main():
     pr.add_argument("--kb", required=True)
     pr.add_argument("--id", required=True)
     pr.add_argument("--type", required=True, choices=["arxiv", "doi"])
+    pr.add_argument("--bib", default=None,
+                    help="existing bib to disambiguate against (collision rule)")
     pr.set_defaults(func=cmd_propose)
     ap = sp.add_parser("append")
     ap.add_argument("--kb", required=True)


### PR DESCRIPTION
## Problem

`append_bibtex.py propose` builds cite keys as `lastname_year_firstword`. Two papers by the same first author, in the same year, whose titles start with the same content word get the same key. `append` then refuses the duplicate with a silent `skip`, and the skill's only guidance is "re-run propose with a different key" — no rule for what that key should be, so different sessions would invent different conventions.

## Change

`propose` gains an optional `--bib` argument pointing at the existing bibliography:

- If the proposed `lastname_year_firstword` is already present, walk to the **next content word of the title** until the key is unique. Example: with `smith_2024_quantum` taken, a second Smith 2024 paper "Quantum sensing with widgets" proposes `smith_2024_sensing`. Keys stay mnemonic and keep their three-part shape.
- The existing key is never renamed — renaming would break citations already written in notes and reviews.
- Identical titles (every word exhausted) fall back to a letter suffix (`smith_2024_quantumb`) as a last resort.
- Without `--bib`, behavior is byte-for-byte unchanged.

SKILL.md's Step 6 command now passes `--bib "$KB/references.bib"`, and the "Cite-key collision" row in Common mistakes points at the rule instead of leaving the choice open.

## Testing

```
$ python3 - <<'PY'
import sys; sys.path.insert(0, 'skills/download-ref/helpers')
from pathlib import Path
from append_bibtex import propose_key
# bib containing @article{smith_2024_quantum, ...}
bib = Path('demo.bib'); bib.write_text('@article{smith_2024_quantum,\n title={x}\n}\n')
meta = {'authors': [{'name': 'J. Smith'}], 'year': 2024, 'title': 'Quantum sensing with widgets'}
print(propose_key(meta, bib))   # -> smith_2024_sensing
print(propose_key(meta))        # -> smith_2024_quantum (no --bib: unchanged)
PY
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)