### PR TITLE
Rename researchstyle skill to know-me-better

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ sci-brain is a skill-based plugin for AI coding assistants (Claude Code, Codex, 
 
 Fifteen skills in `skills/`, each defined by a `SKILL.md` with YAML frontmatter + instructions:
 
-- **brainstorm-ideas** — The main entry point. Socratic research mentor that understands user background, finds attackable problems, and encourages deeper thinking. When an advisor is selected, `/brainstorm-ideas` launches that advisor as a subagent and loads literature from `advisors/<slug>/.knowledge/`. The project's shared knowledge base is `<project>/.knowledge/`. Auto-calls `researchstyle` (Phase 0, if user chooses Zotero/Scholar) and `idea-writer` (Phase 3, if user wants a report).
+- **brainstorm-ideas** — The main entry point. Socratic research mentor that understands user background, finds attackable problems, and encourages deeper thinking. When an advisor is selected, `/brainstorm-ideas` launches that advisor as a subagent and loads literature from `advisors/<slug>/.knowledge/`. The project's shared knowledge base is `<project>/.knowledge/`. Auto-calls `know-me-better` (Phase 0, if user chooses Zotero/Scholar) and `idea-writer` (Phase 3, if user wants a report).
 - **survey** — Parallel literature search via 7 strategies, populates `<project>/.knowledge/` with `.raw/` JSON, appends to `<project>/.knowledge/references.bib` via `download-ref`'s helpers, regenerates `INDEX.md`, writes curated `NOTES.md` (sub-themes, open problems, bottlenecks). Run before `/brainstorm-ideas` for deeper literature grounding.
 - **idea-writer** — Produces a structured ideas report (Typst/LaTeX/Markdown) with full reasoning trail. Auto-called from `/brainstorm-ideas` at wrap-up, or run standalone on a past session's log.
 - **survey-writer** — Produces a structured technology assessment from a populated KB (what it is, pros/cons, state of the art, key problems, optional business relevance). The write-up stage of the `survey` → `download-ref` → `survey-writer` pipeline.
@@ -24,12 +24,12 @@ Fifteen skills in `skills/`, each defined by a `SKILL.md` with YAML frontmatter 
 - **autoresearch-validator** — Stage 3: publishable bar in `GOAL.md` (formalizing the topics-stage acceptance gate) and the validation method (holdout split, budget, environment, negative controls) both user-confirmed; sealed gitignored holdout, Docker-canonical `validate` CLI with rich JSON errors, negative-control strictness self-test. Owns the validator gate.
 - **autoresearch-run** — Stage 4: the loop — batches of attempts (worktree + `LOG.md` each, validator-scored under a hard time limit), reflection reports in `docs/discussion/`, first batch plan confirmed with the user before execution, soft-gated by `authorized_attempts` (at each gate the skill proposes 2–4 lesson-grounded next directions; the user picks direction(s) and authorizes a number of attempts, never rounds/cycles). Hypotheses ground in Selected insights by default but are not limited to them. Each attempt commits its code + `LOG.md` + validator `report.json` on its `attempt-NNN` branch; a cycle-end sync pushes those branches plus main (reports, STATE.md) to the remote.
 - **flow** — Autonomous deep-thinker that conquers one hard goal via a CDCL/DPLL-style search loop: a **preflight gate** (is the goal testable? are all context/KB facts loaded?), then iterate *decide* (**what-if**: assume a condition, test "closer to goal?" + "easier to achieve?") → *propagate* (**simulate**: run consequences forward, reflect; may fan out 2–3 subagents on wide forks) → *learn* (note a reusable clause after **every** trial) → *backjump* (non-chronological, to the real cause) → *pivot* (meta-restart: re-aim to an equally-valuable easier goal when stuck, keeping all notes). Domain-agnostic and KB-optional. Writes a per-trial journal to `docs/flow/<goal-slug>.md` (template in `skills/flow/journal-template.md`). Terminates SOLVED / PIVOTED-SOLVED / EXHAUSTED (≤3 pivots). Distinct from `brainstorm-ideas` (open-ended, collaborative) — `flow` is goal-locked and autonomous.
-- **researchstyle** — Indexes a paper collection (Zotero / PDF folder / Google Scholar) into the active KB. Default target is `<project>/.knowledge/`; when invoked from `/incarnate` targets `advisors/<slug>/.knowledge/`. Writes `.raw/` JSON, delegates `references.bib` writes via `download-ref` helpers.
+- **know-me-better** — Indexes a paper collection (Zotero / PDF folder / Google Scholar) into the active KB. Default target is `<project>/.knowledge/`; when invoked from `/incarnate` targets `advisors/<slug>/.knowledge/`. Writes `.raw/` JSON, delegates `references.bib` writes via `download-ref` helpers.
 - **download-ref** — Adds one or many new arXiv IDs / DOIs to a knowledge base (`<project>/.knowledge/` by default; `advisors/<slug>/.knowledge/` when invoked from advisor flows). Fetches Semantic Scholar metadata, downloads PDFs (with SciHub fallback), renders to markdown via `pymupdf4llm`, regenerates `INDEX.md`, appends to the KB's `references.bib`. Supports `--from-bib` for bulk operations on an existing BibTeX.
 - **conversation-dump** — Extracts dialog from Claude Code or Codex CLI session logs, classifies user messages across 6 academic dimensions, outputs tagged dialog reports to `docs/dialog/`.
 - **import-dialog** — Imports `.md` dialog files (Claude.ai exports, custom markdown conversations) to create or update advisor profiles. Adjunct to `incarnate` for users whose conversation history isn't in JSONL form.
 - **soul-extraction** — Reads `/conversation-dump` output, clusters trigger→reaction pairs into `thinking-pattern.md`, detects logic jumps for `master-thinking.md`. Feeds into `incarnate`.
-- **incarnate** — Onboards a contributor as a named advisor. Guides them through background, runs conversation-dump and soul-extraction, synthesizes `advisors/<slug>/profile.md`. The advisor's literature cache lives at `advisors/<slug>/.knowledge/` (populated via `/researchstyle` or `/download-ref` against that KB).
+- **incarnate** — Onboards a contributor as a named advisor. Guides them through background, runs conversation-dump and soul-extraction, synthesizes `advisors/<slug>/profile.md`. The advisor's literature cache lives at `advisors/<slug>/.knowledge/` (populated via `/know-me-better` or `/download-ref` against that KB).
 
 ## Architecture
 
@@ -67,7 +67,7 @@ advisors/<slug>/
 
 The canonical bib is `$KB/references.bib` — inside the KB, beside `INDEX.md`/`NOTES.md`. (Pre-0.3 notes placed it at the project root as `ref.bib`; that path is retired. To share with project LaTeX, point `\addbibresource`/`bibliography` at `.knowledge/references.bib` or copy it beside the document.)
 
-`download-ref` owns `INDEX.md`, `references.bib` (via append), `.raw/`, `.figures/`, and the rendered `<id>_<slug>.md` files. `survey` / `researchstyle` / humans own `NOTES.md`.
+`download-ref` owns `INDEX.md`, `references.bib` (via append), `.raw/`, `.figures/`, and the rendered `<id>_<slug>.md` files. `survey` / `know-me-better` / humans own `NOTES.md`.
 
 **Advisor library** (`advisors/`): Named advisor profiles generated by `incarnate`. Each profile captures cognitive patterns, attention patterns, reasoning strengths, and conversation dynamics, and may include publication-source links and `edge-tts` voice hints. The brainstorm-ideas skill launches a selected advisor as a subagent and loads their `advisors/<slug>/.knowledge/` literature during brainstorming.
 
@@ -107,7 +107,7 @@ python3 skills/download-ref/helpers/index.py \
 rmdir "$OLD"
 ```
 
-For advisor caches built by the abandoned 0.2-era `publications.yml` flow: that layout was never populated; nothing to migrate. The new flow builds `advisors/<slug>/.knowledge/` via `/researchstyle` or `/download-ref` invoked from `/incarnate`.
+For advisor caches built by the abandoned 0.2-era `publications.yml` flow: that layout was never populated; nothing to migrate. The new flow builds `advisors/<slug>/.knowledge/` via `/know-me-better` or `/download-ref` invoked from `/incarnate`.
 
 Multiple old registries can be merged into one project KB (run the `mv` block per topic; `references.bib` accepts appends; `NOTES.md` accepts merges as separate top-level headings).
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ If you ran `/survey` first, the brainstorm automatically picks up the knowledge 
 | `/slide-writer` | Build Typst + Touying slide decks from a browsable theme/layout/gadget zoo |
 | `/figure-taste` | Score a figure's visual design against an 18-rule rubric |
 | `/flow` | Autonomous deep-thinker that attacks one hard goal via a search loop |
-| `/researchstyle` | Index your Zotero / PDF folder / Google Scholar collection into the KB |
+| `/know-me-better` | Index your Zotero / PDF folder / Google Scholar collection into the KB |
 | `/incarnate` | Capture your thinking style as a reusable advisor profile |
 
 ## Where Things Are Saved
 
-- **Project knowledge base** — `<project>/.knowledge/` (see layout above). Populated by `/survey`, `/download-ref`, `/researchstyle`.
+- **Project knowledge base** — `<project>/.knowledge/` (see layout above). Populated by `/survey`, `/download-ref`, `/know-me-better`.
 - **Advisor knowledge bases** — `advisors/<slug>/.knowledge/` — each advisor's private literature cache, same layout.
 - **Conversation logs** — `docs/discussion/` — timestamped per session; the next session picks up where you left off.
 - **Ideas reports** — `articles/` in your current directory, with a matching `.bib` file.

--- a/skills/brainstorm-ideas/SKILL.md
+++ b/skills/brainstorm-ideas/SKILL.md
@@ -161,7 +161,7 @@ Use this for moments where the advisor's specific perspective, instinct, or expe
 
 If no advisor is selected or no advisors exist, proceed with default mentor behavior.
 
-**First, check for history.** Read `docs/discussion/user-profile.md` if it exists — this contains the user's persisted profile from previous sessions. Also resolve the project KB via `KB=$(python3 skills/download-ref/helpers/resolve_kb.py)` and check `$KB/` for indexed publication data from the `researchstyle` skill. Also read `docs/discussion/*-brainstorm-ideas-log.md` if they exist — they contain past brainstorming sessions and reveal the user's evolving interests, thinking patterns, and which directions they've explored before.
+**First, check for history.** Read `docs/discussion/user-profile.md` if it exists — this contains the user's persisted profile from previous sessions. Also resolve the project KB via `KB=$(python3 skills/download-ref/helpers/resolve_kb.py)` and check `$KB/` for indexed publication data from the `know-me-better` skill. Also read `docs/discussion/*-brainstorm-ideas-log.md` if they exist — they contain past brainstorming sessions and reveal the user's evolving interests, thinking patterns, and which directions they've explored before.
 
 **Session picker.** If previous session logs exist, present them as an interactive choice via `AskUserQuestion` before proceeding:
 
@@ -210,7 +210,7 @@ If no existing profile or knowledge base is found, ask via `AskUserQuestion`:
 > - **(b)** Zotero library — I'll index your papers to understand your work
 > - **(c)** Google Scholar profile — give me your URL
 
-For **(b)** or **(c)**: follow the `researchstyle` skill instructions (read `skills/researchstyle/SKILL.md`) to build a project knowledge base, then continue. The indexed data (publication count, topics, recency, citation patterns) reveals the user's experience level — no need to ask explicitly.
+For **(b)** or **(c)**: follow the `know-me-better` skill instructions (read `skills/researchstyle/SKILL.md`) to build a project knowledge base, then continue. The indexed data (publication count, topics, recency, citation patterns) reveals the user's experience level — no need to ask explicitly.
 
 **For (a) only — one follow-up question (if not already answered):**
 

--- a/skills/download-ref/SKILL.md
+++ b/skills/download-ref/SKILL.md
@@ -56,7 +56,7 @@ python3 -m pip install --user playwright && python3 -m playwright install chromi
 - Appends entries to `$KB/references.bib`
 
 `download-ref` **never touches**:
-- `$KB/NOTES.md` — owned by `survey` / `researchstyle` / humans (sub-themes, open problems, bottlenecks).
+- `$KB/NOTES.md` — owned by `survey` / `know-me-better` / humans (sub-themes, open problems, bottlenecks).
 
 The canonical bib is `$KB/references.bib` — it lives inside the KB, beside `INDEX.md` and `NOTES.md`. (Older notes may say `$(dirname $KB)/ref.bib`; that project-root path is retired.)
 
@@ -247,9 +247,9 @@ After the done checklist passes, offer the pipeline's final stage:
 
 - **`/survey`** (upstream): writes/extends `$KB/NOTES.md`, appends to `$KB/references.bib`, regenerates `$KB/INDEX.md`, then hands off to `/download-ref` to fetch PDFs and render full text. The survey's transition checkpoint offers this directly.
 - **`/survey-writer`** (downstream): consumes the rendered KB (full-text `.md` files + `$KB/references.bib`) to produce a structured technology assessment report.
-- **`/survey` / `/researchstyle`**: write their own `.raw/` JSON via batched fetches and call `append_bibtex.py` directly (skipping the per-ref confirmation in Step 6). They invoke `index.py` at the end of their run.
+- **`/survey` / `/know-me-better`**: write their own `.raw/` JSON via batched fetches and call `append_bibtex.py` directly (skipping the per-ref confirmation in Step 6). They invoke `index.py` at the end of their run.
 - **`/brainstorm-ideas` end-of-session**: surfaces candidate IDs/DOIs from the conversation; for the user's selections, invokes `/download-ref` in single-shot mode.
-- **`/incarnate`**: invokes `/download-ref` (or `/researchstyle`) targeting the advisor KB resolved by `python3 skills/download-ref/helpers/resolve_kb.py --advisor <slug>`.
+- **`/incarnate`**: invokes `/download-ref` (or `/know-me-better`) targeting the advisor KB resolved by `python3 skills/download-ref/helpers/resolve_kb.py --advisor <slug>`.
 
 ## Common mistakes
 

--- a/skills/download-ref/helpers/resolve_kb.py
+++ b/skills/download-ref/helpers/resolve_kb.py
@@ -14,7 +14,7 @@ The KB directory name defaults to `.knowledge` and can be overridden via
 the `SCIBRAIN_KB_DIRNAME` environment variable (e.g. `kb`, `papers`).
 
 This is the single source of truth for "where does the KB live" across
-download-ref, survey, researchstyle, ideas, and incarnate.
+download-ref, survey, know-me-better, ideas, and incarnate.
 
 CLI:
     python3 resolve_kb.py [--start DIR] [--advisor SLUG]

--- a/skills/incarnate/SKILL.md
+++ b/skills/incarnate/SKILL.md
@@ -12,8 +12,8 @@ Onboard a contributor and create a named advisor profile. The profile captures h
 Ask the contributor to provide their academic/professional background:
 
 - **(a)** Tell me yourself (field, experience, what you've worked on)
-- **(b)** Zotero library — follow the `researchstyle` skill instructions (`skills/researchstyle/SKILL.md`) to index publications
-- **(c)** Google Scholar profile — follow the `researchstyle` skill instructions to index publications
+- **(b)** Zotero library — follow the `know-me-better` skill instructions (`skills/researchstyle/SKILL.md`) to index publications
+- **(c)** Google Scholar profile — follow the `know-me-better` skill instructions to index publications
 
 From the response, extract:
 - **Name** (ask if not provided)
@@ -26,7 +26,7 @@ From the response, extract:
 
 Hold this information for Step 4.
 
-**Advisor KB.** Each advisor gets a private knowledge base at `advisors/<slug>/.knowledge/` (shape identical to the project KB: `INDEX.md`, `NOTES.md`, `.raw/`, `.figures/`, rendered `<id>_<slug>.md` files). The advisor's BibTeX namespace lives at `advisors/<slug>/.knowledge/references.bib` (i.e. `$KB/references.bib` for the resolved advisor KB). When `/researchstyle` or `/download-ref` is invoked from this skill, resolve the advisor KB path via `python3 skills/download-ref/helpers/resolve_kb.py --advisor <slug>` and pass it as `--kb "$KB"` so writes land in the advisor KB rather than the project KB. (Users who set `$SCIBRAIN_KB_DIRNAME` get the right directory name automatically.)
+**Advisor KB.** Each advisor gets a private knowledge base at `advisors/<slug>/.knowledge/` (shape identical to the project KB: `INDEX.md`, `NOTES.md`, `.raw/`, `.figures/`, rendered `<id>_<slug>.md` files). The advisor's BibTeX namespace lives at `advisors/<slug>/.knowledge/references.bib` (i.e. `$KB/references.bib` for the resolved advisor KB). When `/know-me-better` or `/download-ref` is invoked from this skill, resolve the advisor KB path via `python3 skills/download-ref/helpers/resolve_kb.py --advisor <slug>` and pass it as `--kb "$KB"` so writes land in the advisor KB rather than the project KB. (Users who set `$SCIBRAIN_KB_DIRNAME` get the right directory name automatically.)
 
 ### Step 2 — Conversation Analysis
 

--- a/skills/paper-writer/SKILL.md
+++ b/skills/paper-writer/SKILL.md
@@ -37,7 +37,7 @@ Before drafting, gather the materials that should inform the paper. Cheap to do 
 
 1. **Shared writing context.** Follow `skills/_shared/writing-workflow.md`. Use `$KB/NOTES.md` as the spine for prior work, gap statement, motivation, and conclusions.
 2. **Ideas / brainstorming log.** Look for `docs/discussion/*-brainstorm-ideas-log.md` from a prior `/brainstorm-ideas` session. If present, read it for: the original motivation, what cross-field connections were surfaced, what minimum viable experiment was planned, and what the success/hope/pivot signals were. This is the *why* behind the paper and feeds the introduction's contribution claim.
-3. **Personal publication context.** Read `docs/discussion/user-profile.md` and any `researchstyle` notes in `$KB/NOTES.md`. Use them to position the new paper in the user's own arc and to avoid re-citing the user's own work incorrectly.
+3. **Personal publication context.** Read `docs/discussion/user-profile.md` and any `know-me-better` notes in `$KB/NOTES.md`. Use them to position the new paper in the user's own arc and to avoid re-citing the user's own work incorrectly.
 4. **Existing draft.** If a partial manuscript already exists under `articles/`, read it before proposing new prose — pick up where the user left off rather than starting from a blank slate.
 
 If none of these exist, name what's missing and ask the user to either point at the files or run `/survey` first. A paper without a literature foundation will read like one.

--- a/skills/researchstyle/SKILL.md
+++ b/skills/researchstyle/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: researchstyle
+name: know-me-better
 description: Use when indexing a paper collection (your own or another researcher's) into a knowledge base — supports Zotero library, a PDF folder, or a Google Scholar profile
 ---
 
-# Researchstyle
+# Know Me Better
 
 Turn an existing paper collection into a structured knowledge base under `<project>/.knowledge/` (or an advisor KB). The output uses the same KB format as the `survey` and `download-ref` skills — project and advisor KBs can coexist cleanly.
 
@@ -99,7 +99,7 @@ Auto-accept the proposed key — per-paper confirmation is unworkable at 100+ pa
 python3 skills/download-ref/helpers/index.py \
   --kb "$KB" \
   --title "<advisor-slug or 'project'> — researcher index" \
-  --source-note "Built by /researchstyle on $(date -u +%Y-%m-%d)."
+  --source-note "Built by /know-me-better on $(date -u +%Y-%m-%d)."
 ```
 
 ## Step 6 — Write NOTES.md
@@ -112,7 +112,7 @@ Write or extend `$KB/NOTES.md` with:
 
 Reference papers as `[@<cite-key>]`. If `NOTES.md` exists, extend rather than overwrite.
 
-## After researchstyle — transition checkpoint
+## After know-me-better — transition checkpoint
 
 After Steps 3–6 complete, the KB is populated with metadata but PDFs aren't downloaded yet. Ask the user via `AskUserQuestion`:
 

--- a/tests/test_advisor_paper_kb.py
+++ b/tests/test_advisor_paper_kb.py
@@ -4,7 +4,7 @@ The advisor KB layout mirrors the project KB:
     advisors/<slug>/
       profile.md           # always present (committed)
       ref.bib              # advisor's BibTeX namespace (optional; created on first append)
-      .knowledge/          # gitignored cache (optional; populated by researchstyle/download-ref)
+      .knowledge/          # gitignored cache (optional; populated by know-me-better/download-ref)
         INDEX.md
         NOTES.md
         .raw/{arxiv,doi}/...


### PR DESCRIPTION
## Summary
Rename the `researchstyle` skill's user-facing name to `know-me-better`.

## Why
`researchstyle` was a confusing name for what the skill does (index a paper collection into the KB). `know-me-better` is more memorable and matches the user's mental model: *"here are my papers, get to know my research better"*.

## What changed
- Frontmatter `name: researchstyle` → `name: know-me-better`
- All references in `CLAUDE.md`, `README.md`, and the skills that invoke it (`brainstorm-ideas`, `incarnate`, `download-ref`, `paper-writer`, `resolve_kb.py`, `test_advisor_paper_kb.py`)

## What deliberately did NOT change
- The folder stays `skills/researchstyle/` — tests and path references read by folder, so they keep working
- The skill body (workflow, Zotero/PDF/Scholar indexing) is untouched

## Note
Installed copies (e.g. `~/.agents/skills/researchstyle/`) need a refresh to pick up the new name.