### PR TITLE
slide-writer: bind math to a real math font (fixes flattened big operators)

### DIFF
--- a/skills/slide-writer/references/style-tokens.md
+++ b/skills/slide-writer/references/style-tokens.md
@@ -66,7 +66,8 @@ sitting on a `pal.primary` fill.
 | Use | Family | Notes |
 |---|---|---|
 | Sans (default body + headings) | DejaVu Sans → Noto Sans | metropolis is a sans theme |
-| Serif (math) | New Computer Modern → Libertinus Serif | bound via `show math.equation: set text(font: fonts.serif)` |
+| Math | New Computer Modern Math → Libertinus Math | bound via `show math.equation: set text(font: fonts.math)`; must be a font with an OpenType MATH table, or operators collapse to letter height |
+| Serif (reserved) | New Computer Modern → Libertinus Serif | unused by the stock themes; available for venue overrides |
 | Mono (code, numerals) | DejaVu Sans Mono → Noto Mono | `codebox`, `data_table`, `time_badge` |
 
 Body size is 20 pt (metropolis default). Gadget body copy sits at 13–14 pt,

--- a/skills/slide-writer/zoo/palettes/academic.typ
+++ b/skills/slide-writer/zoo/palettes/academic.typ
@@ -23,5 +23,6 @@
 #let fonts = (
   sans: ("DejaVu Sans", "Noto Sans"),
   serif: ("New Computer Modern", "Libertinus Serif"),
+  math: ("New Computer Modern Math", "Libertinus Math"),
   mono: ("DejaVu Sans Mono", "Noto Mono"),
 )

--- a/skills/slide-writer/zoo/palettes/brand.typ
+++ b/skills/slide-writer/zoo/palettes/brand.typ
@@ -48,5 +48,6 @@
 #let fonts = (
   sans: ("DejaVu Sans", "Noto Sans"),
   serif: ("New Computer Modern", "Libertinus Serif"),
+  math: ("New Computer Modern Math", "Libertinus Math"),
   mono: ("DejaVu Sans Mono", "Noto Mono"),
 )

--- a/skills/slide-writer/zoo/palettes/dark.typ
+++ b/skills/slide-writer/zoo/palettes/dark.typ
@@ -23,5 +23,6 @@
 #let fonts = (
   sans: ("DejaVu Sans", "Noto Sans"),
   serif: ("New Computer Modern", "Libertinus Serif"),
+  math: ("New Computer Modern Math", "Libertinus Math"),
   mono: ("DejaVu Sans Mono", "Noto Mono"),
 )

--- a/skills/slide-writer/zoo/palettes/minimal.typ
+++ b/skills/slide-writer/zoo/palettes/minimal.typ
@@ -23,5 +23,6 @@
 #let fonts = (
   sans: ("DejaVu Sans", "Noto Sans"),
   serif: ("New Computer Modern", "Libertinus Serif"),
+  math: ("New Computer Modern Math", "Libertinus Math"),
   mono: ("DejaVu Sans Mono", "Noto Mono"),
 )

--- a/skills/slide-writer/zoo/palettes/vibrant.typ
+++ b/skills/slide-writer/zoo/palettes/vibrant.typ
@@ -23,5 +23,6 @@
 #let fonts = (
   sans: ("DejaVu Sans", "Noto Sans"),
   serif: ("New Computer Modern", "Libertinus Serif"),
+  math: ("New Computer Modern Math", "Libertinus Math"),
   mono: ("DejaVu Sans Mono", "Noto Mono"),
 )

--- a/skills/slide-writer/zoo/themes/academic.typ
+++ b/skills/slide-writer/zoo/themes/academic.typ
@@ -6,7 +6,7 @@
 
 #let theme(..args, body) = {
   set text(font: fonts.sans, lang: "en")
-  show math.equation: set text(font: fonts.serif)
+  show math.equation: set text(font: fonts.math)
   show: metropolis-theme.with(
     aspect-ratio: "16-9",
     config-colors(

--- a/skills/slide-writer/zoo/themes/brand.typ
+++ b/skills/slide-writer/zoo/themes/brand.typ
@@ -13,7 +13,7 @@
 #let theme(primary: rgb("#2f2f7f"), ..args, body) = {
   let pal = build(primary)
   set text(font: fonts.sans, lang: "en")
-  show math.equation: set text(font: fonts.serif)
+  show math.equation: set text(font: fonts.math)
   show: metropolis-theme.with(
     aspect-ratio: "16-9",
     config-colors(

--- a/skills/slide-writer/zoo/themes/dark.typ
+++ b/skills/slide-writer/zoo/themes/dark.typ
@@ -6,7 +6,7 @@
 
 #let theme(..args, body) = {
   set text(font: fonts.sans, lang: "en")
-  show math.equation: set text(font: fonts.serif)
+  show math.equation: set text(font: fonts.math)
   show: metropolis-theme.with(
     aspect-ratio: "16-9",
     config-colors(

--- a/skills/slide-writer/zoo/themes/minimal.typ
+++ b/skills/slide-writer/zoo/themes/minimal.typ
@@ -6,7 +6,7 @@
 
 #let theme(..args, body) = {
   set text(font: fonts.sans, lang: "en")
-  show math.equation: set text(font: fonts.serif)
+  show math.equation: set text(font: fonts.math)
   show: metropolis-theme.with(
     aspect-ratio: "16-9",
     footer-progress: false,

--- a/skills/slide-writer/zoo/themes/vibrant.typ
+++ b/skills/slide-writer/zoo/themes/vibrant.typ
@@ -6,7 +6,7 @@
 
 #let theme(..args, body) = {
   set text(font: fonts.sans, lang: "en")
-  show math.equation: set text(font: fonts.serif)
+  show math.equation: set text(font: fonts.math)
   show: metropolis-theme.with(
     aspect-ratio: "16-9",
     config-colors(


### PR DESCRIPTION
## Problem

The five zoo palettes route equations to the **New Computer Modern *text* face**:

```typst
serif: ("New Computer Modern", "Libertinus Serif"),   // palettes/*.typ
show math.equation: set text(font: fonts.serif)        // themes/*.typ
```

That face has no OpenType MATH table, so Typst falls back to plain glyph shaping. The visible damage, in **display math as well as inline**:

- `sum` / `integral` render at letter height, with limits pushed to the side instead of above/below;
- fractions and radicals come out cramped;
- overall spacing loses the TeX math rhythm.

A user reading a deck built with the stock themes immediately notices the "flattened" operators (this is how we found it).

## Fix

Add a `math:` stack to every palette and bind the themes' equation rule to it:

```typst
math: ("New Computer Modern Math", "Libertinus Math"),
show math.equation: set text(font: fonts.math)
```

New Computer Modern Math ships inside Typst itself, so the first entry always resolves — no new font dependency. `serif` is kept (now unused by the stock themes) for venue overrides, and the typography table in `references/style-tokens.md` is updated accordingly.

## Verification

- `gallery.typ` compiles clean under all five themes (`--input theme=academic|dark|minimal|vibrant|brand`).
- A real deck (theorem boxes with display integrals/sums, inline math in prose) renders with proper large operators, raised/lowered limits, and stacked fractions — identical to the LaTeX behaviour the metropolis look implies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
