### PR TITLE
feat(download-ref): fetch APS papers as publisher JATS, not parsed PDF

### DIFF
--- a/skills/how-to-download-ref/SKILL.md
+++ b/skills/how-to-download-ref/SKILL.md
@@ -16,29 +16,48 @@ Do NOT use:
 
 ## Preflight (run once per machine)
 
-The renderer uses **pymupdf4llm** for highest-fidelity output (preserves figures). Fallbacks (`markitdown` → `pdftotext`) are text-only — *figures silently missing*. Verify before fetching:
+`render.py` and `scihub_download.py` carry [PEP 723](https://peps.python.org/pep-0723/)
+inline dependency metadata, so **run those two with `uv run`** and their third-party
+deps (`pymupdf4llm`, `playwright`) are resolved automatically — nothing to install
+by hand, nothing to keep in sync with a system Python:
 
 ```sh
-python3 -c "import pymupdf4llm; print('ok', pymupdf4llm.__version__)"
+uv run skills/how-to-download-ref/helpers/render.py --kb "$KB"
 ```
 
-If that errors, install for the **same** `python3` the helpers will use:
+Every other helper is stdlib-only; plain `python3` is fine for those. Plain
+`python3 render.py` also still works, but only if `pymupdf4llm` happens to be
+importable from that interpreter — otherwise the renderer degrades to
+`markitdown` → `pdftotext`, which is text-only (*figures missing, equations mangled*).
+
+**Install the Tesseract English pack.** PyMuPDF OCRs pages it cannot read as text
+and asks for `eng` by default; if it is absent the whole `to_markdown` call raises
+and the body silently falls through to `pdftotext`. This is the single most common
+cause of bad full text, and it looks like nothing is wrong. Check:
 
 ```sh
-# macOS / Homebrew Python
-/opt/homebrew/bin/python3 -m pip install --user --break-system-packages pymupdf4llm
-
-# Linux / system Python
-python3 -m pip install --user pymupdf4llm
+tesseract --list-langs | grep -qx eng && echo ok || echo "MISSING eng"
 ```
 
-The Sci-Hub fallback (Step 4b) drives a real browser to clear the mirrors'
-DDoS-Guard challenge, so it needs **Playwright** with a Chromium. Only required
-if you expect to hit paywalled DOIs:
+Install `tesseract-data-eng` (Arch), `tesseract-ocr-eng` (Debian/Ubuntu), or
+`brew install tesseract-lang` (macOS).
+
+The Sci-Hub fallback (Step 4b) additionally needs a Chromium for Playwright to
+clear the mirrors' DDoS-Guard challenge. Only required if you expect to hit
+paywalled DOIs:
 
 ```sh
-python3 -m pip install --user playwright && python3 -m playwright install chromium
+uv run --with playwright python -m playwright install chromium
 ```
+
+APS DOIs (`10.1103/*`) render from publisher JATS XML, which needs **pandoc**:
+
+```sh
+pandoc --version | head -1   # any 2.x/3.x works
+```
+
+If missing: `paru -S pandoc-cli` (Arch) / `apt install pandoc` / `brew install pandoc`.
+Without it, APS refs silently fall back to the arXiv/PDF tiers.
 
 For arXiv LaTeX sources (optional, Step 4 — only when the user opts in), `latexpand`
 (ships with TeX Live) gives the cleanest flattening; if absent, a built-in Python
@@ -54,6 +73,8 @@ inliner is used — no action needed either way.
 
 `how-to-download-ref` writes:
 - `$KB/.raw/{arxiv,doi}/<id>.{json,pdf}`
+- `$KB/.raw/doi/<safe-doi>.jats.xml` (publisher JATS for APS DOIs)
+- `$KB/.raw/doi/<safe-doi>.aps.pdf` and `<safe-doi>-suppl/` (only with `--bagit`)
 - `$KB/.raw/{arxiv,doi}/<id>-src/` (extracted e-print source tree — only when LaTeX sources requested)
 - `$KB/.raw/{arxiv,doi}/<id>.tex` (flattened LaTeX; <safe-doi> filenames for DOI entries — only when LaTeX sources requested)
 - `$KB/.figures/{arxiv__<id>,doi__<safe>}/...`
@@ -151,6 +172,17 @@ python3 skills/how-to-download-ref/helpers/fetch_metadata.py \
   --download-arxiv-source
 ```
 
+**APS DOIs are handled automatically.** For any `10.1103/*` DOI the helper first
+calls the [APS Harvest API](https://harvest.aps.org/docs/harvest-api), which serves
+the *publisher's own* JATS XML — real sections, MathML3 equations, a structured
+reference list — with **no API key and no institutional IP**. This is ground truth
+and strictly beats parsing the PDF. Coverage is per *article*, not per journal: you
+get `ok` for gold-OA titles (PRX, PRX Quantum, PRResearch, PRAB, PRPER), SCOAP3
+titles (PRC, PRD), and any individually CC-licensed article in PRL/PRA/PRB;
+`closed` (HTTP 401) falls through to the arXiv and PDF tiers below. Pass `--no-aps`
+to skip. The same request both tests access and delivers the text, so there is no
+separate open-access lookup to do.
+
 Populates `$KB/.raw/{arxiv,doi}/<id>.{json,pdf}` idempotently. PDFs are downloaded sequentially with 2s sleep between requests to avoid arXiv rate limits. Each PDF is verified for a `%%EOF` trailer; truncated downloads are discarded and retried. For DOIs whose publisher gates the PDF (APS / Nature / IOP / AAAS / ACS), the helper falls back to the arXiv preprint via `externalIds.ArXiv` when present. If even that fails, you'll see a `miss` line — go to Step 4b.
 
 `--download-arxiv-source` additionally fetches each arXiv paper's e-print
@@ -170,7 +202,7 @@ If Step 4 reports `miss` for any DOI (no open-access PDF and no arXiv preprint),
 run the browser-based Sci-Hub helper. Pass the missed DOIs:
 
 ```sh
-python3 skills/how-to-download-ref/helpers/scihub_download.py --kb "$KB" \
+uv run skills/how-to-download-ref/helpers/scihub_download.py --kb "$KB" \
   --doi 10.1111/j.1467-9280.2006.01693.x \
   --doi 10.3102/0034654316689306
 ```
@@ -189,28 +221,51 @@ prints one `OK` / `MISS` / `SKIP` line per DOI.
 
 Skip this step if all PDFs were fetched in Step 4.
 
+### 4c. APS extras (optional)
+
+`aps_harvest.py` also runs standalone — useful for backfilling a KB built before
+this path existed, or for pulling figures and supplemental material:
+
+```sh
+# probe one DOI without writing anything -> prints open | closed | notfound
+python3 skills/how-to-download-ref/helpers/aps_harvest.py --check 10.1103/PhysRevB.108.045101
+
+# backfill JATS for every APS DOI already in the KB
+python3 skills/how-to-download-ref/helpers/aps_harvest.py --kb "$KB" --all
+
+# ...and pull the BagIt package too: published PDF, figures, supplemental material
+python3 skills/how-to-download-ref/helpers/aps_harvest.py --kb "$KB" --all --bagit
+```
+
+`--bagit` is the only way to get **supplemental material**, which the arXiv
+preprint route cannot provide. It is much heavier (tens of MB per article), so
+use it per-DOI rather than across a whole KB.
+
 ### 5. Render PDF to markdown
 
 ```sh
-python3 skills/how-to-download-ref/helpers/render.py --kb "$KB"
+uv run skills/how-to-download-ref/helpers/render.py --kb "$KB"
 ```
 
 Add `--only-missing` to skip papers that already have a rendered `.md` file (>500 bytes). This is much faster when adding a few papers to a large KB:
 
 ```sh
-python3 skills/how-to-download-ref/helpers/render.py --kb "$KB" --only-missing
+uv run skills/how-to-download-ref/helpers/render.py --kb "$KB" --only-missing
 ```
 
 When the user opted into LaTeX sources (Step 4, option **b**), add `--tex-source`:
 
 ```sh
-python3 skills/how-to-download-ref/helpers/render.py --kb "$KB" --tex-source
+uv run skills/how-to-download-ref/helpers/render.py --kb "$KB" --tex-source
 ```
 
 No manifest needed — renderer auto-discovers `.raw/{arxiv,doi}/*.json`. Renders new entries; overwrites existing.
 
-**PDF is the default body.** `--tex-source` is the only switch that prefers a
-flattened `.tex` (arXiv entries, and DOI entries with an arXiv preprint) as
+**Body priority: JATS > LaTeX > PDF.** A `.jats.xml` in `.raw/doi/` always wins —
+no flag needed — and renders `full_text: jats` plus a `## References` section built
+from the publisher's structured reference list (every cited DOI/arXiv id included,
+which is a citation graph for free). Below that,
+`--tex-source` is the only switch that prefers a flattened `.tex` (arXiv entries, and DOI entries with an arXiv preprint) as
 the full-text body (`full_text: latex` in frontmatter) — ground truth for
 equations, read natively by agents. Without it, every ref renders from its
 PDF, even when a `.tex` sits in `.raw/`. The PDF backends below apply to all
@@ -304,11 +359,14 @@ After the done checklist passes, offer the pipeline's final stage:
 | Drifting `--title` / `--source-note` between runs | `INDEX.md` regenerates wholesale; first-run values are canonical. Copy verbatim from existing `INDEX.md`. |
 | Expecting `.figures/` images for `full_text: latex` refs to come from the PDF | They come from the source tarball; PDF image extraction runs only on the PDF path. |
 | Rendered from PDF despite a `.tex` in `.raw/` | PDF is the default. To use LaTeX bodies, pass `--tex-source` in Step 5 (and `--download-arxiv-source` in Step 4). |
+| APS paper rendered from PDF, math mangled | `pandoc` is missing, or the article is genuinely `closed`. Check with `aps_harvest.py --check <doi>`. |
+| Reaching for MinerU/Marker on an APS DOI | Try Harvest first — a 401 is the only thing that justifies parsing a PDF at all. |
 
 ## Done checklist
 
 - [ ] `.raw/{arxiv,doi}/<id>.json` exists for every requested id
 - [ ] `.raw/{arxiv,doi}/<id>.pdf` exists where the source allows (else recorded as miss)
+- [ ] For every `10.1103/*` DOI: either `.raw/doi/<safe>.jats.xml` exists (`full_text: jats`) or the fetch logged `closed`
 - [ ] One new `<id>_<slug>.md` per ref at `$KB/` root, with frontmatter
 - [ ] `$KB/INDEX.md` regenerated, lists each new entry
 - [ ] `$KB/references.bib` has the new cite key (no duplicate)

--- a/skills/how-to-download-ref/SKILL.md
+++ b/skills/how-to-download-ref/SKILL.md
@@ -16,19 +16,29 @@ Do NOT use:
 
 ## Preflight (run once per machine)
 
-`render.py` and `scihub_download.py` carry [PEP 723](https://peps.python.org/pep-0723/)
-inline dependency metadata, so **run those two with `uv run`** and their third-party
-deps (`pymupdf4llm`, `playwright`) are resolved automatically — nothing to install
-by hand, nothing to keep in sync with a system Python:
+Every helper runs under plain `python3`. Two of them want third-party packages:
+`render.py` needs **pymupdf4llm** (highest-fidelity output, preserves figures) and
+`scihub_download.py` needs **playwright**. Without them the renderer degrades to
+`markitdown` → `pdftotext`, which is text-only — *figures missing, equations
+mangled*. Verify before fetching:
 
 ```sh
-uv run skills/how-to-download-ref/helpers/render.py --kb "$KB"
+python3 -c "import pymupdf4llm; print('ok', pymupdf4llm.__version__)"
 ```
 
-Every other helper is stdlib-only; plain `python3` is fine for those. Plain
-`python3 render.py` also still works, but only if `pymupdf4llm` happens to be
-importable from that interpreter — otherwise the renderer degrades to
-`markitdown` → `pdftotext`, which is text-only (*figures missing, equations mangled*).
+If that errors, install it for the **same** `python3` the helpers will use:
+
+```sh
+python3 -m pip install --user pymupdf4llm
+# macOS / Homebrew, or any PEP 668 "externally managed" Python:
+python3 -m pip install --user --break-system-packages pymupdf4llm
+```
+
+Both scripts also carry [PEP 723](https://peps.python.org/pep-0723/) inline
+dependency metadata, so if you happen to have [uv](https://docs.astral.sh/uv/),
+`uv run helpers/render.py ...` resolves those deps on its own and you can skip the
+install step entirely. That is an option, not a requirement — the metadata is
+inert comments to a plain interpreter.
 
 **Tesseract is not needed for normal papers.** arXiv and APS PDFs are born-digital,
 so `render.py` runs `pymupdf4llm` with `use_ocr=NEVER` and only retries with OCR
@@ -45,7 +55,7 @@ clear the mirrors' DDoS-Guard challenge. Only required if you expect to hit
 paywalled DOIs:
 
 ```sh
-uv run --with playwright python -m playwright install chromium
+python3 -m pip install --user playwright && python3 -m playwright install chromium
 ```
 
 APS DOIs (`10.1103/*`) render from publisher JATS XML, which needs **pandoc**:
@@ -200,7 +210,7 @@ If Step 4 reports `miss` for any DOI (no open-access PDF and no arXiv preprint),
 run the browser-based Sci-Hub helper. Pass the missed DOIs:
 
 ```sh
-uv run skills/how-to-download-ref/helpers/scihub_download.py --kb "$KB" \
+python3 skills/how-to-download-ref/helpers/scihub_download.py --kb "$KB" \
   --doi 10.1111/j.1467-9280.2006.01693.x \
   --doi 10.3102/0034654316689306
 ```
@@ -242,19 +252,19 @@ use it per-DOI rather than across a whole KB.
 ### 5. Render PDF to markdown
 
 ```sh
-uv run skills/how-to-download-ref/helpers/render.py --kb "$KB"
+python3 skills/how-to-download-ref/helpers/render.py --kb "$KB"
 ```
 
 Add `--only-missing` to skip papers that already have a rendered `.md` file (>500 bytes). This is much faster when adding a few papers to a large KB:
 
 ```sh
-uv run skills/how-to-download-ref/helpers/render.py --kb "$KB" --only-missing
+python3 skills/how-to-download-ref/helpers/render.py --kb "$KB" --only-missing
 ```
 
 When the user opted into LaTeX sources (Step 4, option **b**), add `--tex-source`:
 
 ```sh
-uv run skills/how-to-download-ref/helpers/render.py --kb "$KB" --tex-source
+python3 skills/how-to-download-ref/helpers/render.py --kb "$KB" --tex-source
 ```
 
 No manifest needed — renderer auto-discovers `.raw/{arxiv,doi}/*.json`. Renders new entries; overwrites existing.

--- a/skills/how-to-download-ref/SKILL.md
+++ b/skills/how-to-download-ref/SKILL.md
@@ -30,17 +30,15 @@ Every other helper is stdlib-only; plain `python3` is fine for those. Plain
 importable from that interpreter — otherwise the renderer degrades to
 `markitdown` → `pdftotext`, which is text-only (*figures missing, equations mangled*).
 
-**Install the Tesseract English pack.** PyMuPDF OCRs pages it cannot read as text
-and asks for `eng` by default; if it is absent the whole `to_markdown` call raises
-and the body silently falls through to `pdftotext`. This is the single most common
-cause of bad full text, and it looks like nothing is wrong. Check:
-
-```sh
-tesseract --list-langs | grep -qx eng && echo ok || echo "MISSING eng"
-```
-
-Install `tesseract-data-eng` (Arch), `tesseract-ocr-eng` (Debian/Ubuntu), or
+**Tesseract is not needed for normal papers.** arXiv and APS PDFs are born-digital,
+so `render.py` runs `pymupdf4llm` with `use_ocr=NEVER` and only retries with OCR
+when a PDF turns out to have no text layer at all — a scanned old paper, usually
+from the Sci-Hub tier. Install a language pack only if you hit that:
+`tesseract-data-eng` (Arch), `tesseract-ocr-eng` (Debian/Ubuntu), or
 `brew install tesseract-lang` (macOS).
+
+On Arch in particular, *any* `tesseract-data-*` satisfies the `tessdata`
+dependency, so it is easy to have `tesseract` installed with `eng` absent.
 
 The Sci-Hub fallback (Step 4b) additionally needs a Chromium for Playwright to
 clear the mirrors' DDoS-Guard challenge. Only required if you expect to hit

--- a/skills/how-to-download-ref/helpers/aps_harvest.py
+++ b/skills/how-to-download-ref/helpers/aps_harvest.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Fetch APS published full text (JATS XML) via the APS Harvest API.
+
+The APS Harvest server (https://harvest.aps.org/docs/harvest-api) serves the
+*publisher's own* JATS XML — sections, MathML3 equations, structured reference
+list — for every open-access APS article, with no API key and no institutional
+IP. This is ground truth: no OCR, no two-column layout guessing, no formula
+mangling. It strictly dominates PDF parsing whenever it returns 200.
+
+Coverage is per-article, not per-journal. 200 is returned for gold-OA titles
+(PRX, PRX Quantum, PRResearch, PRAB, PRPER), SCOAP3 titles (PRC, PRD), and any
+individually CC-licensed article in an otherwise closed journal (a large and
+growing share of PRL/PRA/PRB under transformative agreements). Closed articles
+return 401 — that is also the cheapest possible open-access probe, since the
+same request that tests access also delivers the full text.
+
+Usage:
+    aps_harvest.py --kb /abs/path/.knowledge --doi 10.1103/PhysRevLett.130.036401
+    aps_harvest.py --kb /abs/path/.knowledge --all          # every 10.1103 DOI in .raw/doi/
+    aps_harvest.py --kb /abs/path/.knowledge --all --bagit  # + figures & supplemental
+    aps_harvest.py --check 10.1103/PhysRevB.108.045101      # probe only, no write
+
+Writes:
+    .raw/doi/<safe>.jats.xml          publisher JATS (safe = doi with / -> -)
+    .raw/doi/<safe>.aps.pdf           published PDF        (--bagit only)
+    .raw/doi/<safe>-suppl/            supplemental material (--bagit only)
+    .figures/doi__<safe>/             figure files          (--bagit only)
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import html
+import io
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+HARVEST = "https://harvest.aps.org/v2/journals/articles/{doi}"
+UA = "sci-brain-download-ref/1.0 (+https://github.com/QuantumBFS/sci-brain)"
+APS_PREFIX = "10.1103/"
+
+
+def safe_name(doi: str) -> str:
+    return doi.replace("/", "-")
+
+
+def _get(doi: str, accept: str, timeout: int = 120) -> tuple[int, bytes]:
+    req = urllib.request.Request(
+        HARVEST.format(doi=doi), headers={"Accept": accept, "User-Agent": UA})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, b""
+    except Exception as e:  # network / DNS / timeout
+        print(f"  harvest error {doi}: {e}", file=sys.stderr)
+        return 0, b""
+
+
+def fetch_jats(doi: str, out: Path) -> str:
+    """-> ok | cached | closed | notfound | error"""
+    if out.exists() and out.stat().st_size > 2048:
+        return "cached"
+    code, body = _get(doi, "text/xml")
+    if code == 200 and body.lstrip().startswith(b"<?xml"):
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(body)
+        return "ok"
+    if code == 401:
+        return "closed"
+    if code == 404:
+        return "notfound"
+    return "error"
+
+
+def fetch_bagit(doi: str, kb: Path, safe: str) -> str:
+    """Pull the BagIt package: published PDF, figures, supplemental material."""
+    code, body = _get(doi, "application/zip", timeout=600)
+    if code != 200 or not body:
+        return "closed" if code == 401 else "error"
+    try:
+        z = zipfile.ZipFile(io.BytesIO(body))
+    except zipfile.BadZipFile:
+        return "error"
+    figdir = kb / ".figures" / f"doi__{safe}"
+    suppl = kb / ".raw" / "doi" / f"{safe}-suppl"
+    got = []
+    for name in z.namelist():
+        base = Path(name).name
+        if not base:
+            continue
+        if base == "online.pdf":
+            target = kb / ".raw" / "doi" / f"{safe}.aps.pdf"
+        elif "/supplemental_files/" in name:
+            target = suppl / base
+        elif base.startswith("figure_"):
+            # figure_f1.eps.gz -> .figures/doi__<safe>/f1.eps
+            target = figdir / re.sub(r"^figure_", "", base)
+        else:
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        data = z.read(name)
+        if target.name.endswith(".gz"):
+            try:
+                data = gzip.decompress(data)
+                target = target.with_suffix("")
+            except OSError:
+                pass
+        target.write_bytes(data)
+        got.append(target.name)
+    return f"ok ({len(got)} files)" if got else "empty"
+
+
+# ---------------------------------------------------------------- markdown --
+
+_MATH = re.compile(
+    r'<math\b[^>]*?display="(?P<disp>inline|block)".*?'
+    r'<annotation encoding="application/x-tex">(?P<tex>.*?)</annotation>.*?</math>',
+    re.S)
+_FIGURE = re.compile(
+    r'<figure\b(?P<attrs>[^>]*)>(?P<inner>.*?)</figure>', re.S)
+_FIG_ID = re.compile(r'id="(?P<fid>[^"]*)"')
+_FIGCAPTION = re.compile(r'<figcaption>(?P<cap>.*?)</figcaption>', re.S)
+_TAG = re.compile(r'<[^>]+>')
+
+
+def _demath(s: str) -> str:
+    """MathML -> $tex$, using APS's x-tex annotation (always present)."""
+    def sub(m):
+        tex = html.unescape(m.group("tex")).strip()
+        return f"$${tex}$$" if m.group("disp") == "block" else f"${tex}$"
+    return _MATH.sub(sub, s)
+
+
+def _defigure(md: str) -> str:
+    """Collapse pandoc's raw <figure> passthrough into a caption line.
+
+    Figure *files* are only available with --bagit; without them an image link
+    would dangle, so the caption text (which carries the physics) is kept and
+    the <embed> dropped.
+    """
+    def sub(m):
+        inner = m.group("inner")
+        cap = _FIGCAPTION.search(inner)
+        cap = _demath(cap.group("cap")) if cap else ""
+        cap = html.unescape(_TAG.sub("", cap)).strip()
+        cap = re.sub(r"\s+", " ", cap)
+        fid = _FIG_ID.search(m.group("attrs") or "")
+        num = re.sub(r"^f", "", fid.group("fid")) if fid else ""
+        label = f"Figure {num}" if num else "Figure"
+        return f"\n**{label}.** {cap}\n" if cap else ""
+    return _FIGURE.sub(sub, md)
+
+
+def jats_to_markdown(xml_path: Path) -> str:
+    """pandoc JATS -> markdown with LaTeX math, then clean up passthrough HTML."""
+    if not shutil.which("pandoc"):
+        raise RuntimeError("pandoc not found; required for JATS rendering "
+                           "(install: paru -S pandoc-cli / apt install pandoc)")
+    r = subprocess.run(
+        ["pandoc", "-f", "jats", "-t", "markdown+tex_math_dollars",
+         "--wrap=preserve", str(xml_path)],
+        capture_output=True, text=True, timeout=300)
+    if r.returncode != 0:
+        raise RuntimeError(f"pandoc failed on {xml_path.name}: {r.stderr[:300]}")
+    md = _defigure(r.stdout)
+    md = _demath(md)
+    md = _TAG.sub("", md) if "<embed" in md else md
+    md = re.sub(r"\n{3,}", "\n\n", md)
+    return md.strip()
+
+
+# -------------------------------------------------------------- references --
+
+def _txt(el) -> str:
+    return re.sub(r"\s+", " ", "".join(el.itertext())).strip()
+
+
+def extract_refs(xml_path: Path) -> list[dict]:
+    """Structured reference list. APS tags every cited DOI / arXiv id."""
+    root = ET.parse(xml_path).getroot()
+    out = []
+    for ref in root.findall(".//ref"):
+        cit = ref.find("mixed-citation")
+        if cit is None:
+            cit = ref.find("element-citation")
+        if cit is None:
+            continue
+        d = {"id": ref.get("id") or ""}
+        lbl = ref.find("label")
+        d["label"] = _txt(lbl).strip("[]") if lbl is not None else ""
+        d["authors"] = [_txt(n) for n in cit.findall(".//string-name")]
+        for tag, key in (("article-title", "title"), ("source", "source"),
+                         ("volume", "volume"), ("page-range", "pages"),
+                         ("fpage", "pages"), ("year", "year")):
+            el = cit.find(tag)
+            if el is not None and not d.get(key):
+                d[key] = _txt(el)
+        link = cit.find("ext-link")
+        if link is not None:
+            d["url"] = (link.get("{http://www.w3.org/1999/xlink}href")
+                        or _txt(link))
+        oid = cit.find("object-id")
+        raw = _txt(cit)
+        if oid is not None:
+            raw = raw.replace(_txt(oid), "", 1).strip()
+        d["raw"] = raw
+        for pid in cit.findall("pub-id"):
+            t = pid.get("pub-id-type")
+            if t == "doi":
+                d["doi"] = _txt(pid)
+            elif t == "arxiv":
+                d["arxiv"] = _txt(pid).replace("arXiv:", "")
+        out.append(d)
+    return out
+
+
+def render_refs_md(refs: list[dict]) -> str:
+    lines = []
+    for r in refs:
+        au = ", ".join(r.get("authors") or [])
+        if len(r.get("authors") or []) > 4:
+            au = f"{r['authors'][0]} et al."
+        bits = [b for b in (au, r.get("title")) if b]
+        cite = " ".join(x for x in (
+            r.get("source"), r.get("volume"),
+            r.get("pages"), f"({r['year']})" if r.get("year") else "") if x)
+        if cite:
+            bits.append(cite)
+        links = []
+        if r.get("doi"):
+            links.append(f"[doi:{r['doi']}](https://doi.org/{r['doi']})")
+        if r.get("arxiv"):
+            links.append(f"[arXiv:{r['arxiv']}](https://arxiv.org/abs/{r['arxiv']})")
+        if r.get("url") and not links:
+            links.append(f"<{r['url']}>")
+        tail = "  " + " ".join(links) if links else ""
+        body = ". ".join(b.rstrip(". ") for b in bits if b.strip())
+        if not body:
+            # misc/unstructured citation (a bare URL, a software note, ...)
+            body = r.get("raw", "").rstrip(". ")
+        lines.append(f"{r.get('label') or r.get('id')}. {body}." + tail)
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------- cli --
+
+def aps_dois_in_kb(kb: Path) -> list[str]:
+    doi_dir = kb / ".raw" / "doi"
+    if not doi_dir.exists():
+        return []
+    found = []
+    for j in sorted(doi_dir.glob("*.json")):
+        try:
+            s2 = json.loads(j.read_text())
+        except Exception:
+            continue
+        doi = (s2.get("externalIds") or {}).get("DOI") or ""
+        if doi.lower().startswith(APS_PREFIX):
+            found.append(doi)
+    return found
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--kb", type=Path, help="Absolute path to <stream>/.knowledge/")
+    p.add_argument("--doi", action="append", default=[], help="APS DOI (repeatable)")
+    p.add_argument("--all", action="store_true",
+                   help="Process every 10.1103/* DOI already in .raw/doi/")
+    p.add_argument("--bagit", action="store_true",
+                   help="Also pull the BagIt package (published PDF, figures, supplemental)")
+    p.add_argument("--check", metavar="DOI",
+                   help="Probe open-access status only; print open/closed and exit")
+    args = p.parse_args()
+
+    if args.check:
+        code, _ = _get(args.check, "text/xml", timeout=30)
+        print({200: "open", 401: "closed", 404: "notfound"}.get(code, f"error({code})"))
+        return 0 if code == 200 else 1
+
+    if not args.kb:
+        p.error("--kb is required unless --check is used")
+    dois = list(args.doi)
+    if args.all:
+        dois += [d for d in aps_dois_in_kb(args.kb) if d not in dois]
+    dois = [d for d in dois if d.lower().startswith(APS_PREFIX)]
+    if not dois:
+        print("no APS (10.1103/*) DOIs to process")
+        return 0
+
+    raw_doi = args.kb / ".raw" / "doi"
+    n_ok = n_closed = 0
+    for i, doi in enumerate(dois):
+        safe = safe_name(doi)
+        status = fetch_jats(doi, raw_doi / f"{safe}.jats.xml")
+        extra = ""
+        if status in ("ok", "cached"):
+            n_ok += 1
+            if args.bagit:
+                extra = f" bagit={fetch_bagit(doi, args.kb, safe)}"
+        elif status == "closed":
+            n_closed += 1
+        print(f"  {status:8s} {doi}{extra}")
+        if status not in ("cached",) and i < len(dois) - 1:
+            time.sleep(1)
+    print(f"\njats: {n_ok} open, {n_closed} closed (closed -> arXiv/PDF tiers)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/how-to-download-ref/helpers/fetch_metadata.py
+++ b/skills/how-to-download-ref/helpers/fetch_metadata.py
@@ -104,6 +104,8 @@ def main() -> int:
                    help="Also fetch arXiv preprint PDFs (incl. preprints of paywalled DOIs)")
     p.add_argument("--download-arxiv-source", action="store_true",
                    help="Also fetch arXiv e-print LaTeX sources, flattened to .raw/arxiv/<id>.tex")
+    p.add_argument("--no-aps", action="store_true",
+                   help="Skip the APS Harvest JATS fetch for 10.1103/* DOIs (on by default)")
     args = p.parse_args()
 
     raw = args.kb / ".raw"
@@ -128,6 +130,18 @@ def main() -> int:
             safe = k.replace("/", "-")
             save(raw / "doi" / f"{safe}.json", r)
         summarize("doi", k, r)
+
+    if not args.no_aps and dois:
+        from aps_harvest import APS_PREFIX, fetch_jats, safe_name
+        aps = [d for d in dois if d.lower().startswith(APS_PREFIX)]
+        if aps:
+            print(f"\nAPS Harvest: publisher JATS for {len(aps)} DOI(s) "
+                  f"(no key needed; 401 = closed, falls through to arXiv/PDF)...")
+            for i, d in enumerate(aps):
+                st = fetch_jats(d, raw / "doi" / f"{safe_name(d)}.jats.xml")
+                print(f"  {st:8s} {d}")
+                if st != "cached" and i < len(aps) - 1:
+                    time.sleep(1)
 
     if args.download_arxiv_pdfs:
         print("\nfetching PDFs (sequential with 2s sleep to avoid arXiv rate limits)...")

--- a/skills/how-to-download-ref/helpers/render.py
+++ b/skills/how-to-download-ref/helpers/render.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pymupdf4llm"]
+# ///
 """Render the .raw/ assets into .knowledge/ markdown.
 
 Reads:
 - .raw/{arxiv,doi}/<id>.json — Semantic Scholar metadata (from fetch_metadata.py)
 - .raw/{arxiv,doi}/<id>.pdf — original PDFs (optional; rendered as full-text section)
+- .raw/doi/<safe>.jats.xml — publisher JATS from the APS Harvest API (optional;
+  ALWAYS preferred as the full-text body when present — it is the published
+  version, with exact TeX from MathML and a structured reference list)
 - .raw/{arxiv,doi}/<id>.tex — flattened arXiv LaTeX source (optional; used as the
   full-text body ONLY with --tex-source; otherwise PDF->markdown is the default)
 - .raw/repos/<owner>-<repo>/ — shallow clones (rendered as README + ls-tree)
@@ -106,6 +113,13 @@ def extract_pdf_text(pdf: Path, kb: Path | None = None, fig_subdir: str | None =
             print("  pymupdf4llm not installed; falling back to markitdown/pdftotext", file=sys.stderr)
         except Exception as e:
             print(f"  pymupdf4llm {pdf.name}: {e}", file=sys.stderr)
+            if "esseract" in str(e):
+                print("  ^ PyMuPDF OCRs pages it cannot read as text and asks for the "
+                      "English pack by default. Install it (tesseract-data-eng on Arch, "
+                      "tesseract-ocr-eng on Debian/Ubuntu, `brew install tesseract-lang` "
+                      "on macOS); otherwise ONE unreadable page discards the whole "
+                      "document and the body silently degrades to pdftotext.",
+                      file=sys.stderr)
 
     tmp_md = Path("/tmp") / (pdf.stem + ".md")
     tmp_txt = Path("/tmp") / (pdf.stem + ".txt")
@@ -123,6 +137,9 @@ def extract_pdf_text(pdf: Path, kb: Path | None = None, fig_subdir: str | None =
                                capture_output=True, text=True, timeout=120)
             if r.returncode == 0 and tmp_txt.exists():
                 text = tmp_txt.read_text(errors="replace")
+                print(f"  WARNING {pdf.name}: fell through to pdftotext. Equations and "
+                      f"two-column layout will be mangled; treat the body as unreliable. "
+                      f"Prefer JATS (aps_harvest.py) or arXiv LaTeX source.", file=sys.stderr)
         except Exception:
             pass
     for p in (tmp_md, tmp_txt):
@@ -222,7 +239,25 @@ def render_doi(kb: Path, raw: Path, only_missing: bool = False, use_tex: bool = 
         body += ["", "## Abstract", "", s2.get("abstract") or "_(abstract unavailable)_"]
         pdf = doi_dir / f"{safe}.pdf"
         tex = doi_dir / f"{safe}.tex"
-        if use_tex and tex.exists() and tex.stat().st_size > 100:
+        jats = doi_dir / f"{safe}.jats.xml"
+        jats_md, jats_refs = "", []
+        if jats.exists() and jats.stat().st_size > 2048:
+            # Publisher JATS beats both LaTeX preprint and PDF: it is the
+            # published version, its MathML carries exact TeX, and its
+            # reference list is fully structured. See aps_harvest.py.
+            try:
+                from aps_harvest import extract_refs, jats_to_markdown, render_refs_md
+                jats_md = jats_to_markdown(jats)
+                jats_refs = extract_refs(jats)
+            except Exception as e:
+                print(f"  jats {safe}: {e}", file=sys.stderr)
+        if jats_md:
+            meta["full_text"] = "jats"
+            body[0] = render_frontmatter(meta)
+            body += ["", "## Full Text (publisher JATS)", "", jats_md]
+            if jats_refs:
+                body += ["", "## References", "", render_refs_md(jats_refs)]
+        elif use_tex and tex.exists() and tex.stat().st_size > 100:
             meta["full_text"] = "latex"
             body[0] = render_frontmatter(meta)
             body += ["", "## Full Text (LaTeX source)", "",

--- a/skills/how-to-download-ref/helpers/render.py
+++ b/skills/how-to-download-ref/helpers/render.py
@@ -93,20 +93,38 @@ def extract_pdf_text(pdf: Path, kb: Path | None = None, fig_subdir: str | None =
     if kb is not None and fig_subdir:
         try:
             import pymupdf4llm  # type: ignore
+            try:
+                from pymupdf4llm.ocr import OCRMode  # pymupdf4llm >= 1.28
+            except ImportError:
+                OCRMode = None
             fig_abs = kb / ".figures" / fig_subdir
             fig_abs.mkdir(parents=True, exist_ok=True)
             rel_path = f".figures/{fig_subdir}"
-            old_cwd = os.getcwd()
-            try:
-                os.chdir(kb)
-                md = pymupdf4llm.to_markdown(
-                    str(pdf),
-                    write_images=True,
-                    image_path=rel_path,
-                    image_format="png",
-                )
-            finally:
-                os.chdir(old_cwd)
+            def _to_md(**extra):
+                old_cwd = os.getcwd()
+                try:
+                    os.chdir(kb)
+                    return pymupdf4llm.to_markdown(
+                        str(pdf),
+                        write_images=True,
+                        image_path=rel_path,
+                        image_format="png",
+                        **extra,
+                    )
+                finally:
+                    os.chdir(old_cwd)
+
+            # Papers from arXiv/APS are born-digital: the text layer is already
+            # there, so OCR buys nothing, costs a lot of time, and drags in a
+            # hard tessdata dependency. Worse, pymupdf4llm's default
+            # (select-keep) OCRs pages it judges sparse, and a single page whose
+            # OCR cannot initialise raises and discards the WHOLE document.
+            # Skip it, and only reach for OCR if the text layer really is empty
+            # -- a scanned old paper, typically via the Sci-Hub tier.
+            md = _to_md(use_ocr=OCRMode.NEVER) if OCRMode else _to_md()
+            if OCRMode and (not md or len(md.strip()) <= 100):
+                print(f"  {pdf.name}: no text layer, retrying with OCR", file=sys.stderr)
+                md = _to_md()
             if md and len(md.strip()) > 100:
                 text = md
         except ImportError:
@@ -114,11 +132,12 @@ def extract_pdf_text(pdf: Path, kb: Path | None = None, fig_subdir: str | None =
         except Exception as e:
             print(f"  pymupdf4llm {pdf.name}: {e}", file=sys.stderr)
             if "esseract" in str(e):
-                print("  ^ PyMuPDF OCRs pages it cannot read as text and asks for the "
-                      "English pack by default. Install it (tesseract-data-eng on Arch, "
-                      "tesseract-ocr-eng on Debian/Ubuntu, `brew install tesseract-lang` "
-                      "on macOS); otherwise ONE unreadable page discards the whole "
-                      "document and the body silently degrades to pdftotext.",
+                print("  ^ This PDF has no text layer, so it needs OCR, and the English "
+                      "Tesseract pack is missing. Install it (tesseract-data-eng on Arch "
+                      "-- note any tesseract-data-* satisfies the `tessdata` dependency "
+                      "there, so `eng` is easy to end up without; tesseract-ocr-eng on "
+                      "Debian/Ubuntu; `brew install tesseract-lang` on macOS). "
+                      "Born-digital papers do not reach this path.",
                       file=sys.stderr)
 
     tmp_md = Path("/tmp") / (pdf.stem + ".md")

--- a/skills/how-to-download-ref/helpers/scihub_download.py
+++ b/skills/how-to-download-ref/helpers/scihub_download.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "playwright",
+#     "tomli; python_version < '3.11'",
+# ]
+# ///
 """Browser-based Sci-Hub fallback for paywalled PDFs.
 
 Replaces the old `sci-hub-server` MCP. A real (headless) browser is required


### PR DESCRIPTION
## Problem

For APS DOIs (`10.1103/*`) `download-ref` treated the PDF as the source of truth, so full text came out of `pymupdf4llm`/`pdftotext`. On dense two-column Physical Review typesetting that mangles exactly the part that matters — the equations.

It turns out none of that parsing is necessary for a large share of APS. The [APS Harvest API](https://harvest.aps.org/docs/harvest-api) serves the publisher's own JATS XML — real section structure, MathML3 equations, a fully structured reference list — **with no API key and no institutional IP**.

Coverage is per *article*, not per journal:

| DOI | Harvest |
|---|---|
| `10.1103/PhysRevX.5.021001` | 200 (gold OA) |
| `10.1103/PhysRevLett.130.036401` | 200 (CC-licensed article in a closed journal) |
| `10.1103/PhysRevD.106.075011` | 200 (SCOAP3) |
| `10.1103/PhysRevB.108.045101` | 401 |
| `10.1103/RevModPhys.94.045006` | 401 |

Probed from a subscribing university's IP, and PRB/RMP still 401 — so this is not institutional access leaking through, it is per-article open-access status. `401` falls through to the existing arXiv and PDF tiers, and the same request that tests access also delivers the text, so this adds no separate open-access lookup.

## What changed

- **`helpers/aps_harvest.py`** (new). Fetches JATS for `10.1103/*`, renders it through `pandoc` with MathML unwound to LaTeX via APS's `x-tex` annotations, and extracts the structured reference list — every cited DOI/arXiv id, which is a citation graph for free. `--bagit` also pulls the published PDF, figures and **supplemental material** (the arXiv route cannot provide the latter). `--check` probes open-access status without writing.
- **`fetch_metadata.py`** — runs the JATS fetch for APS DOIs by default; `--no-aps` opts out.
- **`render.py`** — body priority is now **JATS > LaTeX > PDF**, plus a `## References` section from the publisher list.

### Two adjacent papercuts

Both silently produced bad bodies that looked like successful extraction:

- `render.py` fell through to `pdftotext -layout` without saying so. It now warns.
- `render.py` asked `pymupdf4llm` to OCR. Papers from arXiv and APS are born-digital, so OCR buys nothing there — but the default mode (`select-keep`) sends pages it judges sparse to Tesseract, requesting `eng`. Where that pack is absent the exception propagates out of `to_markdown` and discards the **entire** document; one figure-heavy page is enough. It now runs with `use_ocr=NEVER` and retries with OCR only when a PDF genuinely has no text layer — a scanned old paper, usually from the Sci-Hub tier.

  Verified against an empty `TESSDATA_PREFIX`: the arXiv ref renders 94 KB with 124 figures extracted, where before it fell through to `pdftotext`. A synthesised image-only PDF still takes the OCR retry and comes back with its title intact. `OCRMode` arrived in `pymupdf4llm` 1.28, so the import is guarded and older versions keep the previous behaviour.

  Worth noting for packagers: on Arch *any* `tesseract-data-*` satisfies the `tessdata` dependency, so having `tesseract` installed without `eng` is an easy state to reach — which is how this surfaced.

### uv

`render.py` and `scihub_download.py` gain [PEP 723](https://peps.python.org/pep-0723/) inline metadata, so `uv run` resolves `pymupdf4llm` / `playwright` on its own — no more `pip install --user --break-system-packages` against a PEP 668 system Python. Both stay runnable under a plain `python3` that already has the deps; the metadata is inert comments. Every other helper is stdlib-only and unchanged.

## Testing

End-to-end on a scratch KB, 3 APS DOIs:

```
  ok       10.1103/PhysRevLett.130.036401   ->  34.1 KB  full_text=jats
  ok       10.1103/PhysRevX.5.021001        ->  57.0 KB  full_text=jats
  closed   10.1103/PhysRevB.108.045101      ->   725 B   full_text=no
```

Rendered bodies carry clean display math (`$$\Psi(\{\mathbf{x}_{j}\}) = \sum\limits_{k}^{n_{\det}}\det\lbrack\ldots\rbrack$$`), anchored heading hierarchy, `Fig. [1](#f1)` cross-references, and 54 references each with a resolvable DOI link. Zero residual `<math>` / `<figure>` / `<embed>` / `mml:` markup.

Regressions checked: arXiv-only refs, a non-APS DOI with no preprint (Nature), `--no-aps`, and `uv run` vs `python3` invocation. `--tex-source` behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)