### PR TITLE
fix(download-ref): normalise APS DOI case before asking Harvest

### DIFF
--- a/skills/how-to-download-ref/SKILL.md
+++ b/skills/how-to-download-ref/SKILL.md
@@ -413,6 +413,7 @@ After the done checklist passes, offer the pipeline's final stage:
 | Rendered from PDF despite a `.tex` in `.raw/` | PDF is the default. To use LaTeX bodies, pass `--tex-source` in Step 5 (and `--download-arxiv-source` in Step 4). |
 | APS paper rendered from PDF, math mangled | `pandoc` is missing, or the article is genuinely `closed`. Check with `aps_harvest.py --check <doi>`. |
 | Reaching for MinerU/Marker on an APS DOI | Try Harvest first — a 401 is the only thing that justifies parsing a PDF at all. |
+| APS DOI reported `notfound` | Harvest matches the DOI suffix case-sensitively; `aps_harvest.canonical_doi` restores APS's capitalisation before the request. Add the journal to `APS_JOURNAL_TOKENS` if a new title 404s. |
 
 ## Done checklist
 

--- a/skills/how-to-download-ref/helpers/aps_harvest.py
+++ b/skills/how-to-download-ref/helpers/aps_harvest.py
@@ -55,7 +55,35 @@ def safe_name(doi: str) -> str:
     return doi.replace("/", "-")
 
 
-def _get(doi: str, accept: str, timeout: int = 120) -> tuple[int, bytes]:
+# harvest.aps.org matches the DOI suffix case-sensitively: PhysRevX.5.021001
+# returns 200 where physrevx.5.021001 returns 404. DOIs are case-insensitive by
+# spec, Crossref hands them back lowercased, and this skill's own docs say
+# "lowercase preferred" -- so a lowercased APS DOI would read as "not found" and
+# fall through to PDF parsing with nothing to show why. Restore the casing APS
+# expects before asking. Longest token first: PhysRevApplied must win over
+# PhysRevA, PhysRevMaterials over PhysRev.
+APS_JOURNAL_TOKENS = sorted((
+    "PhysRev", "PhysRevSeriesI", "PhysRevA", "PhysRevB", "PhysRevC", "PhysRevD",
+    "PhysRevE", "PhysRevX", "PhysRevLett", "PhysRevResearch", "PhysRevApplied",
+    "PhysRevMaterials", "PhysRevFluids", "PhysRevAccelBeams", "PhysRevSTAB",
+    "PhysRevSTPER", "PhysRevPhysEducRes", "RevModPhys", "PRXQuantum",
+    "PRXEnergy", "PRXLife", "PRXIntelligence",
+), key=len, reverse=True)
+
+
+def canonical_doi(doi: str) -> str:
+    """Restore APS's capitalisation of the journal token in an APS DOI."""
+    if not doi.lower().startswith(APS_PREFIX):
+        return doi
+    prefix, _, suffix = doi.partition("/")
+    low = suffix.lower()
+    for token in APS_JOURNAL_TOKENS:
+        if low.startswith(token.lower()):
+            return f"{prefix}/{token}{suffix[len(token):]}"
+    return doi
+
+
+def _request(doi: str, accept: str, timeout: int) -> tuple[int, bytes]:
     req = urllib.request.Request(
         HARVEST.format(doi=doi), headers={"Accept": accept, "User-Agent": UA})
     try:
@@ -66,6 +94,15 @@ def _get(doi: str, accept: str, timeout: int = 120) -> tuple[int, bytes]:
     except Exception as e:  # network / DNS / timeout
         print(f"  harvest error {doi}: {e}", file=sys.stderr)
         return 0, b""
+
+
+def _get(doi: str, accept: str, timeout: int = 120) -> tuple[int, bytes]:
+    canon = canonical_doi(doi)
+    code, body = _request(canon, accept, timeout)
+    if code == 404 and canon != doi:
+        # an APS journal this mapping does not know about yet
+        code, body = _request(doi, accept, timeout)
+    return code, body
 
 
 def fetch_jats(doi: str, out: Path) -> str:


### PR DESCRIPTION
Follow-up to #49.

## The bug

`harvest.aps.org` matches the DOI suffix **case-sensitively**:

| DOI | Harvest |
|---|---|
| `10.1103/PhysRevX.5.021001` | 200 |
| `10.1103/physrevx.5.021001` | 404 |

DOIs are case-insensitive by spec, Crossref returns them lowercased, and this skill's own **Inputs** section says *"DOIs … lowercase preferred; renderer normalizes"*. So a lowercased APS DOI — the common case when a manifest comes from a `.bib` or from Crossref — read as `notfound`, fell through to the arXiv/PDF tiers, and silently lost the publisher JATS that #49 exists to fetch.

I found it while sampling PRB: twelve real PRB DOIs pulled straight from the Crossref API returned **404 for all twelve**. With the casing restored the same twelve return **401**, which is the honest answer — PRB is a hybrid journal, so most of its articles are closed. The 404s were hiding that distinction entirely.

## The fix

`canonical_doi()` maps the journal token back to APS's spelling, longest token first so `PhysRevApplied` wins over `PhysRevA` and `PhysRevMaterials` over `PhysRev`. A 404 on the canonical form retries the DOI as given, so an APS title missing from the table behaves exactly as it does today.

## Verified

Live against the API, lowercased:

```
10.1103/physrevx.5.021001        200   194822 B
10.1103/physrevlett.130.036401   200    93454 B
10.1103/physrevb.48.12511        200    48878 B
10.1103/prxquantum.2.010101      200   270666 B
10.1103/physrevb.108.045101      401         0 B   <- correctly closed, not 404
```

Plus a nine-case table check of `canonical_doi` covering PRX, PRB, PRL, PR Applied, PR Materials, PRX Quantum, RMP, the old `PhysRev`, and a non-APS DOI left untouched. End-to-end, a lowercase PRL DOI now renders `full_text: jats`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)