### PR TITLE
ci: pin actions to SHAs, add dependabot and SECURITY.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
     name: Validate skills + run tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
     name: Publish sci-brain to npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # npm trusted publishing requires Node >= 22.14.0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+sci-brain is a set of skills and helper scripts. It runs no server and stores no credentials. Helpers call public APIs (Semantic Scholar, CrossRef, arXiv, Unpaywall) and read only the optional `SCIBRAIN_CONTACT_EMAIL` environment variable.
+
+## Reporting a vulnerability
+
+Open a [private security advisory](https://github.com/QuantumBFS/sci-brain/security/advisories/new). Do not file a public issue for security reports. Expect a first response within 7 days.
+
+## Supported versions
+
+Only the latest release receives fixes.


### PR DESCRIPTION
## Summary

The listing PR hashgraph-online/awesome-ai-plugins#248 (from #53) runs the HOL plugin scanner against this repo and requires a score of 80. It scored 75, failing their CI.

- Pin `actions/checkout`, `actions/setup-python`, `actions/setup-node` to commit SHAs of the same majors already in use, with version comments.
- Add `.github/dependabot.yml` for monthly GitHub Actions updates.
- Add `SECURITY.md` pointing to private advisories.

Local scanner (`uvx --from plugin-scanner plugin-scanner scan .`) now reports 95/100. The only remaining warning is the absent lockfile, which does not apply since `package.json` has no dependencies.

## Test plan

- [x] `python3 scripts/validate_skills.py`
- [x] `pytest -q` (246 passed)
- [x] Local scanner score 95

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KR2icPWUEhxD2CbJpBWBW